### PR TITLE
Add `only` and `except` support for `inputs`, `internals` and `outputs`

### DIFF
--- a/examples/usual/example58.rb
+++ b/examples/usual/example58.rb
@@ -5,6 +5,7 @@ module Usual
     input :first_name, type: String
     input :middle_name, type: String
     input :last_name, type: String
+    input :gender, type: String
 
     output :full_name, type: String
 

--- a/examples/usual/example58.rb
+++ b/examples/usual/example58.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Usual
+  class Example58 < ApplicationService::Base
+    input :first_name, type: String
+    input :middle_name, type: String, required: false
+    input :last_name, type: String
+
+    output :full_name, type: String
+
+    make :assign_full_name
+
+    private
+
+    def assign_full_name
+      outputs.full_name = inputs.only(:first_name, :middle_name, :last_name).values.compact.join(" ")
+    end
+  end
+end

--- a/examples/usual/example58.rb
+++ b/examples/usual/example58.rb
@@ -3,7 +3,7 @@
 module Usual
   class Example58 < ApplicationService::Base
     input :first_name, type: String
-    input :middle_name, type: String, required: false
+    input :middle_name, type: String
     input :last_name, type: String
 
     output :full_name, type: String

--- a/examples/usual/example59.rb
+++ b/examples/usual/example59.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Usual
+  class Example59 < ApplicationService::Base
+    input :first_name, type: String
+    input :middle_name, type: String
+    input :last_name, type: String
+    input :gender, type: String
+
+    output :full_name, type: String
+
+    make :assign_full_name
+
+    private
+
+    def assign_full_name
+      outputs.full_name = inputs.except(:gender).values.compact.join(" ")
+    end
+  end
+end

--- a/examples/usual/example60.rb
+++ b/examples/usual/example60.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  class Example60 < ApplicationService::Base
+    input :first_name, type: String
+    input :middle_name, type: String
+    input :last_name, type: String
+    input :gender, type: String
+
+    internal :first_name, type: String
+    internal :middle_name, type: String
+    internal :last_name, type: String
+    internal :gender, type: String
+
+    output :full_name, type: String
+
+    make :prepare_names
+    make :assign_full_name
+
+    private
+
+    def prepare_names
+      internals.first_name = inputs.first_name.upcase
+      internals.middle_name = inputs.middle_name.upcase
+      internals.last_name = inputs.last_name.upcase
+    end
+
+    def assign_full_name
+      outputs.full_name = internals.only(:first_name, :middle_name, :last_name).values.compact.join(" ")
+    end
+  end
+end

--- a/examples/usual/example61.rb
+++ b/examples/usual/example61.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  class Example61 < ApplicationService::Base
+    input :first_name, type: String
+    input :middle_name, type: String
+    input :last_name, type: String
+    input :gender, type: String
+
+    internal :first_name, type: String
+    internal :middle_name, type: String
+    internal :last_name, type: String
+    internal :gender, type: String
+
+    output :full_name, type: String
+
+    make :prepare_names
+    make :assign_full_name
+
+    private
+
+    def prepare_names
+      internals.first_name = inputs.first_name.upcase
+      internals.middle_name = inputs.middle_name.upcase
+      internals.last_name = inputs.last_name.upcase
+    end
+
+    def assign_full_name
+      outputs.full_name = internals.except(:gender).values.compact.join(" ")
+    end
+  end
+end

--- a/examples/usual/example62.rb
+++ b/examples/usual/example62.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  class Example62 < ApplicationService::Base
+    input :first_name, type: String
+    input :middle_name, type: String
+    input :last_name, type: String
+    input :gender, type: String
+
+    internal :full_name, type: String
+    internal :gender, type: String
+
+    output :first_name, type: String
+    output :middle_name, type: String
+    output :last_name, type: String
+
+    make :assign_prepared_names
+    make :assign_full_name
+
+    private
+
+    def assign_prepared_names
+      outputs.first_name = inputs.first_name.upcase
+      outputs.middle_name = inputs.middle_name.upcase
+      outputs.last_name = inputs.last_name.upcase
+    end
+
+    def assign_full_name
+      internals.full_name = outputs.only(:first_name, :middle_name, :last_name).values.compact.join(" ")
+    end
+  end
+end

--- a/examples/usual/example62.rb
+++ b/examples/usual/example62.rb
@@ -7,12 +7,10 @@ module Usual
     input :last_name, type: String
     input :gender, type: String
 
-    internal :full_name, type: String
-    internal :gender, type: String
-
     output :first_name, type: String
     output :middle_name, type: String
     output :last_name, type: String
+    output :full_name, type: String
 
     make :assign_prepared_names
     make :assign_full_name
@@ -26,7 +24,7 @@ module Usual
     end
 
     def assign_full_name
-      internals.full_name = outputs.only(:first_name, :middle_name, :last_name).values.compact.join(" ")
+      outputs.full_name = outputs.only(:first_name, :middle_name, :last_name).values.compact.join(" ")
     end
   end
 end

--- a/examples/usual/example63.rb
+++ b/examples/usual/example63.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  class Example63 < ApplicationService::Base
+    input :first_name, type: String
+    input :middle_name, type: String
+    input :last_name, type: String
+    input :gender, type: String
+
+    internal :full_name, type: String
+    internal :gender, type: String
+
+    output :first_name, type: String
+    output :middle_name, type: String
+    output :last_name, type: String
+
+    make :assign_prepared_names
+    make :assign_full_name
+
+    private
+
+    def assign_prepared_names
+      outputs.first_name = inputs.first_name.upcase
+      outputs.middle_name = inputs.middle_name.upcase
+      outputs.last_name = inputs.last_name.upcase
+    end
+
+    def assign_full_name
+      internals.full_name = outputs.except(:gender).values.compact.join(" ")
+    end
+  end
+end

--- a/examples/usual/example63.rb
+++ b/examples/usual/example63.rb
@@ -7,12 +7,10 @@ module Usual
     input :last_name, type: String
     input :gender, type: String
 
-    internal :full_name, type: String
-    internal :gender, type: String
-
     output :first_name, type: String
     output :middle_name, type: String
     output :last_name, type: String
+    output :full_name, type: String
 
     make :assign_prepared_names
     make :assign_full_name
@@ -26,7 +24,7 @@ module Usual
     end
 
     def assign_full_name
-      internals.full_name = outputs.except(:gender).values.compact.join(" ")
+      outputs.full_name = outputs.except(:gender).values.compact.join(" ")
     end
   end
 end

--- a/lib/servactory/context/workspace/inputs.rb
+++ b/lib/servactory/context/workspace/inputs.rb
@@ -16,6 +16,12 @@ module Servactory
             .to_h { |input| [input.internal_name, send(:"#{input.internal_name}")] }
         end
 
+        def except(*input_names)
+          @collection_of_inputs
+            .except(*input_names)
+            .to_h { |input| [input.internal_name, send(:"#{input.internal_name}")] }
+        end
+
         def method_missing(name, *args, &block)
           if name.to_s.end_with?("=")
             prepared_name = name.to_s.delete("=").to_sym

--- a/lib/servactory/context/workspace/inputs.rb
+++ b/lib/servactory/context/workspace/inputs.rb
@@ -10,6 +10,12 @@ module Servactory
           @collection_of_inputs = collection_of_inputs
         end
 
+        def only(*input_names)
+          @collection_of_inputs
+            .only(*input_names)
+            .to_h { |input| [input.internal_name, send(:"#{input.internal_name}")] }
+        end
+
         def method_missing(name, *args, &block)
           if name.to_s.end_with?("=")
             prepared_name = name.to_s.delete("=").to_sym

--- a/lib/servactory/context/workspace/inputs.rb
+++ b/lib/servactory/context/workspace/inputs.rb
@@ -13,13 +13,13 @@ module Servactory
         def only(*input_names)
           @collection_of_inputs
             .only(*input_names)
-            .to_h { |input| [input.internal_name, send(:"#{input.internal_name}")] }
+            .to_h { |input| [input.internal_name, send(input.internal_name)] }
         end
 
         def except(*input_names)
           @collection_of_inputs
             .except(*input_names)
-            .to_h { |input| [input.internal_name, send(:"#{input.internal_name}")] }
+            .to_h { |input| [input.internal_name, send(input.internal_name)] }
         end
 
         def method_missing(name, *args, &block)

--- a/lib/servactory/context/workspace/inputs.rb
+++ b/lib/servactory/context/workspace/inputs.rb
@@ -10,15 +10,15 @@ module Servactory
           @collection_of_inputs = collection_of_inputs
         end
 
-        def only(*input_names)
+        def only(*names)
           @collection_of_inputs
-            .only(*input_names)
+            .only(*names)
             .to_h { |input| [input.internal_name, send(input.internal_name)] }
         end
 
-        def except(*input_names)
+        def except(*names)
           @collection_of_inputs
-            .except(*input_names)
+            .except(*names)
             .to_h { |input| [input.internal_name, send(input.internal_name)] }
         end
 

--- a/lib/servactory/context/workspace/internals.rb
+++ b/lib/servactory/context/workspace/internals.rb
@@ -15,6 +15,12 @@ module Servactory
             .to_h { |internal| [internal.name, send(internal.name)] }
         end
 
+        def except(*internal_names)
+          @collection_of_internals
+            .except(*internal_names)
+            .to_h { |internal| [internal.name, send(internal.name)] }
+        end
+
         def method_missing(name, *args, &block)
           if name.to_s.end_with?("=")
             prepared_name = name.to_s.delete("=").to_sym

--- a/lib/servactory/context/workspace/internals.rb
+++ b/lib/servactory/context/workspace/internals.rb
@@ -9,6 +9,12 @@ module Servactory
           @collection_of_internals = collection_of_internals
         end
 
+        def only(*internal_names)
+          @collection_of_internals
+            .only(*internal_names)
+            .to_h { |internal| [internal.name, send(internal.name)] }
+        end
+
         def method_missing(name, *args, &block)
           if name.to_s.end_with?("=")
             prepared_name = name.to_s.delete("=").to_sym

--- a/lib/servactory/context/workspace/internals.rb
+++ b/lib/servactory/context/workspace/internals.rb
@@ -9,15 +9,15 @@ module Servactory
           @collection_of_internals = collection_of_internals
         end
 
-        def only(*internal_names)
+        def only(*names)
           @collection_of_internals
-            .only(*internal_names)
+            .only(*names)
             .to_h { |internal| [internal.name, send(internal.name)] }
         end
 
-        def except(*internal_names)
+        def except(*names)
           @collection_of_internals
-            .except(*internal_names)
+            .except(*names)
             .to_h { |internal| [internal.name, send(internal.name)] }
         end
 

--- a/lib/servactory/context/workspace/outputs.rb
+++ b/lib/servactory/context/workspace/outputs.rb
@@ -15,6 +15,12 @@ module Servactory
             .to_h { |output| [output.name, send(output.name)] }
         end
 
+        def except(*names)
+          @collection_of_outputs
+            .except(*names)
+            .to_h { |output| [output.name, send(output.name)] }
+        end
+
         def method_missing(name, *args, &block)
           if name.to_s.end_with?("=")
             prepared_name = name.to_s.delete("=").to_sym

--- a/lib/servactory/context/workspace/outputs.rb
+++ b/lib/servactory/context/workspace/outputs.rb
@@ -9,6 +9,12 @@ module Servactory
           @collection_of_outputs = collection_of_outputs
         end
 
+        def only(*names)
+          @collection_of_outputs
+            .only(*names)
+            .to_h { |output| [output.name, send(output.name)] }
+        end
+
         def method_missing(name, *args, &block)
           if name.to_s.end_with?("=")
             prepared_name = name.to_s.delete("=").to_sym

--- a/lib/servactory/inputs/collection.rb
+++ b/lib/servactory/inputs/collection.rb
@@ -15,6 +15,10 @@ module Servactory
         Collection.new(filter { |input| input_names.include?(input.internal_name) })
       end
 
+      def except(*input_names)
+        Collection.new(filter { |input| !input_names.include?(input.internal_name) })
+      end
+
       def names
         map(&:name)
       end

--- a/lib/servactory/inputs/collection.rb
+++ b/lib/servactory/inputs/collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Inputs
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :filter, :each, :map, :to_h, :merge, :find
 

--- a/lib/servactory/inputs/collection.rb
+++ b/lib/servactory/inputs/collection.rb
@@ -10,12 +10,12 @@ module Servactory
         @collection = collection
       end
 
-      def only(*input_names)
-        Collection.new(filter { |input| input_names.include?(input.internal_name) })
+      def only(*names)
+        Collection.new(filter { |input| names.include?(input.internal_name) })
       end
 
-      def except(*input_names)
-        Collection.new(filter { |input| !input_names.include?(input.internal_name) })
+      def except(*names)
+        Collection.new(filter { |input| !names.include?(input.internal_name) })
       end
 
       def names

--- a/lib/servactory/inputs/collection.rb
+++ b/lib/servactory/inputs/collection.rb
@@ -5,10 +5,14 @@ module Servactory
     class Collection
       # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
-      def_delegators :@collection, :<<, :each, :map, :merge, :find
+      def_delegators :@collection, :<<, :filter, :each, :map, :to_h, :merge, :find
 
-      def initialize(*)
-        @collection = Set.new
+      def initialize(collection = Set.new)
+        @collection = collection
+      end
+
+      def only(*input_names)
+        Collection.new(filter { |input| input_names.include?(input.internal_name) })
       end
 
       def names

--- a/lib/servactory/inputs/option_helpers_collection.rb
+++ b/lib/servactory/inputs/option_helpers_collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Inputs
     class OptionHelpersCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :find, :merge
 

--- a/lib/servactory/inputs/options_collection.rb
+++ b/lib/servactory/inputs/options_collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Inputs
     class OptionsCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :filter, :each, :map, :flat_map, :find
 

--- a/lib/servactory/inputs/tools/check_errors.rb
+++ b/lib/servactory/inputs/tools/check_errors.rb
@@ -4,7 +4,6 @@ module Servactory
   module Inputs
     module Tools
       class CheckErrors
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
         def_delegators :@collection, :merge, :reject, :first, :empty?
 

--- a/lib/servactory/inputs/validations/errors.rb
+++ b/lib/servactory/inputs/validations/errors.rb
@@ -4,7 +4,6 @@ module Servactory
   module Inputs
     module Validations
       class Errors
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
         def_delegators :@collection, :<<, :to_a
 

--- a/lib/servactory/internals/collection.rb
+++ b/lib/servactory/internals/collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Internals
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :filter, :each, :map, :to_h, :merge, :find
 

--- a/lib/servactory/internals/collection.rb
+++ b/lib/servactory/internals/collection.rb
@@ -5,10 +5,14 @@ module Servactory
     class Collection
       # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
-      def_delegators :@collection, :<<, :each, :map, :merge, :find
+      def_delegators :@collection, :<<, :filter, :each, :map, :to_h, :merge, :find
 
-      def initialize(*)
-        @collection = Set.new
+      def initialize(collection = Set.new)
+        @collection = collection
+      end
+
+      def only(*internal_names)
+        Collection.new(filter { |internal| internal_names.include?(internal.name) })
       end
 
       def names

--- a/lib/servactory/internals/collection.rb
+++ b/lib/servactory/internals/collection.rb
@@ -10,12 +10,12 @@ module Servactory
         @collection = collection
       end
 
-      def only(*internal_names)
-        Collection.new(filter { |internal| internal_names.include?(internal.name) })
+      def only(*names)
+        Collection.new(filter { |internal| names.include?(internal.name) })
       end
 
-      def except(*internal_names)
-        Collection.new(filter { |internal| !internal_names.include?(internal.name) })
+      def except(*names)
+        Collection.new(filter { |internal| !names.include?(internal.name) })
       end
 
       def names

--- a/lib/servactory/internals/collection.rb
+++ b/lib/servactory/internals/collection.rb
@@ -15,6 +15,10 @@ module Servactory
         Collection.new(filter { |internal| internal_names.include?(internal.name) })
       end
 
+      def except(*internal_names)
+        Collection.new(filter { |internal| !internal_names.include?(internal.name) })
+      end
+
       def names
         map(&:name)
       end

--- a/lib/servactory/methods/aliases_for_make/collection.rb
+++ b/lib/servactory/methods/aliases_for_make/collection.rb
@@ -4,7 +4,6 @@ module Servactory
   module Methods
     module AliasesForMake
       class Collection
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
         def_delegators :@collection, :<<, :merge, :include?
 

--- a/lib/servactory/methods/method_collection.rb
+++ b/lib/servactory/methods/method_collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Methods
     class MethodCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :each, :sort_by
 

--- a/lib/servactory/methods/shortcuts_for_make/collection.rb
+++ b/lib/servactory/methods/shortcuts_for_make/collection.rb
@@ -4,7 +4,6 @@ module Servactory
   module Methods
     module ShortcutsForMake
       class Collection
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
         def_delegators :@collection, :<<, :each, :merge, :include?
 

--- a/lib/servactory/methods/stage_collection.rb
+++ b/lib/servactory/methods/stage_collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Methods
     class StageCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :each, :merge, :sort_by, :size, :empty?
 

--- a/lib/servactory/outputs/collection.rb
+++ b/lib/servactory/outputs/collection.rb
@@ -3,7 +3,6 @@
 module Servactory
   module Outputs
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
       def_delegators :@collection, :<<, :filter, :each, :map, :to_h, :merge, :find
 

--- a/lib/servactory/outputs/collection.rb
+++ b/lib/servactory/outputs/collection.rb
@@ -5,10 +5,14 @@ module Servactory
     class Collection
       # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
-      def_delegators :@collection, :<<, :each, :map, :merge, :find
+      def_delegators :@collection, :<<, :filter, :each, :map, :to_h, :merge, :find
 
-      def initialize(*)
-        @collection = Set.new
+      def initialize(collection = Set.new)
+        @collection = collection
+      end
+
+      def only(*internal_names)
+        Collection.new(filter { |internal| internal_names.include?(internal.name) })
       end
 
       def names

--- a/lib/servactory/outputs/collection.rb
+++ b/lib/servactory/outputs/collection.rb
@@ -10,12 +10,12 @@ module Servactory
         @collection = collection
       end
 
-      def only(*internal_names)
-        Collection.new(filter { |internal| internal_names.include?(internal.name) })
+      def only(*names)
+        Collection.new(filter { |internal| names.include?(internal.name) })
       end
 
-      def except(*internal_names)
-        Collection.new(filter { |internal| !internal_names.include?(internal.name) })
+      def except(*names)
+        Collection.new(filter { |internal| !names.include?(internal.name) })
       end
 
       def names

--- a/lib/servactory/outputs/collection.rb
+++ b/lib/servactory/outputs/collection.rb
@@ -15,6 +15,10 @@ module Servactory
         Collection.new(filter { |internal| internal_names.include?(internal.name) })
       end
 
+      def except(*internal_names)
+        Collection.new(filter { |internal| !internal_names.include?(internal.name) })
+      end
+
       def names
         map(&:name)
       end

--- a/sig/lib/servactory/context/workspace/inputs.rbs
+++ b/sig/lib/servactory/context/workspace/inputs.rbs
@@ -8,7 +8,7 @@ module Servactory
 
         def initialize: (context: instance, incoming_arguments: untyped, collection_of_inputs: Servactory::Inputs::Collection) -> void
 
-        def only: (Array[Symbol] input_names) -> Hash[Symbol, untyped]
+        def only: (Symbol input_names) -> Hash[Symbol, untyped]
 
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 

--- a/sig/lib/servactory/context/workspace/inputs.rbs
+++ b/sig/lib/servactory/context/workspace/inputs.rbs
@@ -8,6 +8,8 @@ module Servactory
 
         def initialize: (context: instance, incoming_arguments: untyped, collection_of_inputs: Servactory::Inputs::Collection) -> void
 
+        def only: (Array[Symbol] input_names) -> Hash[Symbol, untyped]
+
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 
         def respond_to_missing?: (Symbol name, *untyped) -> void

--- a/sig/lib/servactory/context/workspace/inputs.rbs
+++ b/sig/lib/servactory/context/workspace/inputs.rbs
@@ -10,6 +10,8 @@ module Servactory
 
         def only: (Symbol input_names) -> Hash[Symbol, untyped]
 
+        def except: (Symbol input_names) -> Hash[Symbol, untyped]
+
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 
         def respond_to_missing?: (Symbol name, *untyped) -> void

--- a/sig/lib/servactory/context/workspace/internals.rbs
+++ b/sig/lib/servactory/context/workspace/internals.rbs
@@ -7,6 +7,8 @@ module Servactory
 
         def initialize: (context: instance, collection_of_internals: Servactory::Internals::Collection) -> void
 
+        def only: (Symbol internal_names) -> Hash[Symbol, untyped]
+
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 
         def respond_to_missing?: (Symbol name, *untyped) -> void

--- a/sig/lib/servactory/context/workspace/internals.rbs
+++ b/sig/lib/servactory/context/workspace/internals.rbs
@@ -9,6 +9,8 @@ module Servactory
 
         def only: (Symbol internal_names) -> Hash[Symbol, untyped]
 
+        def except: (Symbol internal_names) -> Hash[Symbol, untyped]
+
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 
         def respond_to_missing?: (Symbol name, *untyped) -> void

--- a/sig/lib/servactory/context/workspace/outputs.rbs
+++ b/sig/lib/servactory/context/workspace/outputs.rbs
@@ -7,6 +7,8 @@ module Servactory
 
         def initialize: (context: instance, collection_of_outputs: Servactory::Outputs::Collection) -> void
 
+        def only: (Symbol names) -> Hash[Symbol, untyped]
+
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 
         def respond_to_missing?: (Symbol name, *untyped) -> void

--- a/sig/lib/servactory/context/workspace/outputs.rbs
+++ b/sig/lib/servactory/context/workspace/outputs.rbs
@@ -9,6 +9,8 @@ module Servactory
 
         def only: (Symbol names) -> Hash[Symbol, untyped]
 
+        def except: (Symbol names) -> Hash[Symbol, untyped]
+
         def method_missing: (Symbol name, *untyped args) { () -> untyped } -> void
 
         def respond_to_missing?: (Symbol name, *untyped) -> void

--- a/sig/lib/servactory/errors/collection.rbs
+++ b/sig/lib/servactory/errors/collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Errors
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[Failure | InputError | InternalError | OutputError]

--- a/sig/lib/servactory/inputs/checks/errors.rbs
+++ b/sig/lib/servactory/inputs/checks/errors.rbs
@@ -2,7 +2,6 @@ module Servactory
   module Inputs
     module Validations
       class Errors
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
 
         @collection: Set[String]

--- a/sig/lib/servactory/inputs/collection.rbs
+++ b/sig/lib/servactory/inputs/collection.rbs
@@ -10,6 +10,8 @@ module Servactory
 
       def only: (Array[Symbol] input_names) -> Collection
 
+      def except: (Array[Symbol] input_names) -> Collection
+
       def names: () -> Array[Symbol]
 
       def find_by: (name: Symbol) -> Input?

--- a/sig/lib/servactory/inputs/collection.rbs
+++ b/sig/lib/servactory/inputs/collection.rbs
@@ -4,9 +4,11 @@ module Servactory
       # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
-      @collection: Set[Input]
+      @collection: (Set[Input] | Collection)
 
-      def initialize: (*untyped) -> void
+      def initialize: ((Set[Input] | Collection) collection) -> void
+
+      def only: (Array[Symbol] input_names) -> Collection
 
       def names: () -> Array[Symbol]
 

--- a/sig/lib/servactory/inputs/collection.rbs
+++ b/sig/lib/servactory/inputs/collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Inputs
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[Input]

--- a/sig/lib/servactory/inputs/collection.rbs
+++ b/sig/lib/servactory/inputs/collection.rbs
@@ -4,9 +4,9 @@ module Servactory
       # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
-      @collection: (Set[Input] | Collection)
+      @collection: Set[Input]
 
-      def initialize: ((Set[Input] | Collection) collection) -> void
+      def initialize: (Set[Input] collection) -> void
 
       def only: (Array[Symbol] input_names) -> Collection
 

--- a/sig/lib/servactory/inputs/option_helpers_collection.rbs
+++ b/sig/lib/servactory/inputs/option_helpers_collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Inputs
     class OptionHelpersCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[OptionHelper]

--- a/sig/lib/servactory/inputs/options_collection.rbs
+++ b/sig/lib/servactory/inputs/options_collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Inputs
     class OptionsCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[Option]

--- a/sig/lib/servactory/inputs/tools/check_errors.rbs
+++ b/sig/lib/servactory/inputs/tools/check_errors.rbs
@@ -2,7 +2,6 @@ module Servactory
   module Inputs
     module Tools
       class CheckErrors
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
 
         @collection: Set[String]

--- a/sig/lib/servactory/internals/collection.rbs
+++ b/sig/lib/servactory/internals/collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Internals
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[Internal]

--- a/sig/lib/servactory/internals/collection.rbs
+++ b/sig/lib/servactory/internals/collection.rbs
@@ -4,9 +4,11 @@ module Servactory
       # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
-      @collection: Set[Collection]
+      @collection: Set[Internal]
 
-      def initialize: (*untyped) -> void
+      def initialize: (Set[Internal] collection) -> void
+
+      def only: (Array[Symbol] internal_names) -> Collection
 
       def names: () -> Array[Symbol]
 

--- a/sig/lib/servactory/internals/collection.rbs
+++ b/sig/lib/servactory/internals/collection.rbs
@@ -10,6 +10,8 @@ module Servactory
 
       def only: (Array[Symbol] internal_names) -> Collection
 
+      def except: (Array[Symbol] internal_names) -> Collection
+
       def names: () -> Array[Symbol]
 
       def find_by: (name: Symbol) -> Internal?

--- a/sig/lib/servactory/methods/aliases_for_make/collection.rbs
+++ b/sig/lib/servactory/methods/aliases_for_make/collection.rbs
@@ -2,7 +2,6 @@ module Servactory
   module Methods
     module AliasesForMake
       class Collection
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
 
         @collection: Set[Symbol]

--- a/sig/lib/servactory/methods/method_collection.rbs
+++ b/sig/lib/servactory/methods/method_collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Methods
     class MethodCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[Method]

--- a/sig/lib/servactory/methods/shortcuts_for_make/collection.rbs
+++ b/sig/lib/servactory/methods/shortcuts_for_make/collection.rbs
@@ -2,7 +2,6 @@ module Servactory
   module Methods
     module ShortcutsForMake
       class Collection
-        # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
         extend Forwardable
 
         @collection: Set[Symbol]

--- a/sig/lib/servactory/methods/stage_collection.rbs
+++ b/sig/lib/servactory/methods/stage_collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Methods
     class StageCollection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[StageCollection]

--- a/sig/lib/servactory/outputs/collection.rbs
+++ b/sig/lib/servactory/outputs/collection.rbs
@@ -10,6 +10,8 @@ module Servactory
 
       def only: (Array[Symbol] names) -> Collection
 
+      def except: (Array[Symbol] names) -> Collection
+
       def names: () -> Array[Symbol]
 
       def find_by: (name: Symbol) -> Output?

--- a/sig/lib/servactory/outputs/collection.rbs
+++ b/sig/lib/servactory/outputs/collection.rbs
@@ -1,7 +1,6 @@
 module Servactory
   module Outputs
     class Collection
-      # NOTE: http://words.steveklabnik.com/beware-subclassing-ruby-core-classes
       extend Forwardable
 
       @collection: Set[Output]

--- a/sig/lib/servactory/outputs/collection.rbs
+++ b/sig/lib/servactory/outputs/collection.rbs
@@ -6,7 +6,9 @@ module Servactory
 
       @collection: Set[Output]
 
-      def initialize: (*untyped) -> void
+      def initialize: (Set[Output] collection) -> void
+
+      def only: (Array[Symbol] names) -> Collection
 
       def names: () -> Array[Symbol]
 

--- a/spec/examples/usual/example16_spec.rb
+++ b/spec/examples/usual/example16_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example16 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example17_spec.rb
+++ b/spec/examples/usual/example17_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example17 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 
@@ -79,7 +79,7 @@ RSpec.describe Usual::Example17 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example1_spec.rb
+++ b/spec/examples/usual/example1_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example1 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[full_name]
 
@@ -76,7 +76,7 @@ RSpec.describe Usual::Example1 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example23_spec.rb
+++ b/spec/examples/usual/example23_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Usual::Example23 do
     let(:date) { DateTime.new(2023, 1, 1) }
 
     include_examples "check class info",
-                     inputs: %i[api_identifier date first_name last_name middle_name],
+                     inputs: %i[api_identifier date first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[api_response]
 
@@ -73,7 +73,7 @@ RSpec.describe Usual::Example23 do
     let(:date) { DateTime.new(2023, 1, 1) }
 
     include_examples "check class info",
-                     inputs: %i[api_identifier date first_name last_name middle_name],
+                     inputs: %i[api_identifier date first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[api_response]
 

--- a/spec/examples/usual/example2_spec.rb
+++ b/spec/examples/usual/example2_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example2 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 
@@ -76,7 +76,7 @@ RSpec.describe Usual::Example2 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example3_spec.rb
+++ b/spec/examples/usual/example3_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example3 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 
@@ -76,7 +76,7 @@ RSpec.describe Usual::Example3 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[prepared_full_name],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example4_spec.rb
+++ b/spec/examples/usual/example4_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example4 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[full_name]
 
@@ -62,7 +62,7 @@ RSpec.describe Usual::Example4 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example51_spec.rb
+++ b/spec/examples/usual/example51_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Usual::Example51 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[
                        full_name_1 full_name_2 full_name_3 full_name_4
@@ -98,7 +98,7 @@ RSpec.describe Usual::Example51 do
     let(:last_name) { "Kennedy" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name middle_name last_name],
                      internals: %i[],
                      outputs: %i[
                        full_name_1 full_name_2 full_name_3 full_name_4

--- a/spec/examples/usual/example58_spec.rb
+++ b/spec/examples/usual/example58_spec.rb
@@ -8,16 +8,18 @@ RSpec.describe Usual::Example58 do
       {
         first_name: first_name,
         middle_name: middle_name,
-        last_name: last_name
+        last_name: last_name,
+        gender: gender
       }
     end
 
     let(:first_name) { "John" }
     let(:middle_name) { "Fitzgerald" }
     let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name last_name middle_name gender],
                      internals: %i[],
                      outputs: %i[full_name]
 
@@ -47,6 +49,11 @@ RSpec.describe Usual::Example58 do
       context "when `last_name`" do
         it_behaves_like "input required check", name: :last_name
         it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
       end
     end
   end
@@ -58,16 +65,18 @@ RSpec.describe Usual::Example58 do
       {
         first_name: first_name,
         middle_name: middle_name,
-        last_name: last_name
+        last_name: last_name,
+        gender: gender
       }
     end
 
     let(:first_name) { "John" }
     let(:middle_name) { "Fitzgerald" }
     let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name],
+                     inputs: %i[first_name last_name middle_name gender],
                      internals: %i[],
                      outputs: %i[full_name]
 
@@ -97,6 +106,11 @@ RSpec.describe Usual::Example58 do
       context "when `last_name`" do
         it_behaves_like "input required check", name: :last_name
         it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
       end
     end
   end

--- a/spec/examples/usual/example58_spec.rb
+++ b/spec/examples/usual/example58_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Usual::Example58 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
                      internals: %i[],
                      outputs: %i[full_name]
 
@@ -76,7 +76,7 @@ RSpec.describe Usual::Example58 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
                      internals: %i[],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example58_spec.rb
+++ b/spec/examples/usual/example58_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Example58 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name],
+                     internals: %i[],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("John Fitzgerald Kennedy")
+        end
+
+        describe "even if `middle_name` is not specified" do
+          let(:middle_name) { nil }
+
+          it "returns the expected value in `full_name`" do
+            result = perform
+
+            expect(result.full_name).to eq("John Kennedy")
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name],
+                     internals: %i[],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("John Fitzgerald Kennedy")
+        end
+
+        describe "even if `middle_name` is not specified" do
+          let(:middle_name) { nil }
+
+          it "returns the expected value in `full_name`" do
+            result = perform
+
+            expect(result.full_name).to eq("John Kennedy")
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/example58_spec.rb
+++ b/spec/examples/usual/example58_spec.rb
@@ -30,16 +30,6 @@ RSpec.describe Usual::Example58 do
 
           expect(result.full_name).to eq("John Fitzgerald Kennedy")
         end
-
-        describe "even if `middle_name` is not specified" do
-          let(:middle_name) { nil }
-
-          it "returns the expected value in `full_name`" do
-            result = perform
-
-            expect(result.full_name).to eq("John Kennedy")
-          end
-        end
       end
     end
 
@@ -50,6 +40,7 @@ RSpec.describe Usual::Example58 do
       end
 
       context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
         it_behaves_like "input type check", name: :middle_name, expected_type: String
       end
 
@@ -89,16 +80,6 @@ RSpec.describe Usual::Example58 do
 
           expect(result.full_name).to eq("John Fitzgerald Kennedy")
         end
-
-        describe "even if `middle_name` is not specified" do
-          let(:middle_name) { nil }
-
-          it "returns the expected value in `full_name`" do
-            result = perform
-
-            expect(result.full_name).to eq("John Kennedy")
-          end
-        end
       end
     end
 
@@ -109,6 +90,7 @@ RSpec.describe Usual::Example58 do
       end
 
       context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
         it_behaves_like "input type check", name: :middle_name, expected_type: String
       end
 

--- a/spec/examples/usual/example59_spec.rb
+++ b/spec/examples/usual/example59_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Example59 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name gender],
+                     internals: %i[],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("John Fitzgerald Kennedy")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name gender],
+                     internals: %i[],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("John Fitzgerald Kennedy")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/example59_spec.rb
+++ b/spec/examples/usual/example59_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Usual::Example59 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
                      internals: %i[],
                      outputs: %i[full_name]
 
@@ -76,7 +76,7 @@ RSpec.describe Usual::Example59 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
                      internals: %i[],
                      outputs: %i[full_name]
 

--- a/spec/examples/usual/example60_spec.rb
+++ b/spec/examples/usual/example60_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Usual::Example60 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
-                     internals: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[first_name middle_name last_name gender],
                      outputs: %i[full_name]
 
     context "when the input arguments are valid" do
@@ -76,8 +76,8 @@ RSpec.describe Usual::Example60 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
-                     internals: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[first_name middle_name last_name gender],
                      outputs: %i[full_name]
 
     context "when the input arguments are valid" do

--- a/spec/examples/usual/example60_spec.rb
+++ b/spec/examples/usual/example60_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Example60 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name gender],
+                     internals: %i[first_name last_name middle_name gender],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name gender],
+                     internals: %i[first_name last_name middle_name gender],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/example61_spec.rb
+++ b/spec/examples/usual/example61_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Usual::Example61 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
-                     internals: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[first_name middle_name last_name gender],
                      outputs: %i[full_name]
 
     context "when the input arguments are valid" do
@@ -76,8 +76,8 @@ RSpec.describe Usual::Example61 do
     let(:gender) { "Male" }
 
     include_examples "check class info",
-                     inputs: %i[first_name last_name middle_name gender],
-                     internals: %i[first_name last_name middle_name gender],
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[first_name middle_name last_name gender],
                      outputs: %i[full_name]
 
     context "when the input arguments are valid" do

--- a/spec/examples/usual/example61_spec.rb
+++ b/spec/examples/usual/example61_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Example61 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name gender],
+                     internals: %i[first_name last_name middle_name gender],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name last_name middle_name gender],
+                     internals: %i[first_name last_name middle_name gender],
+                     outputs: %i[full_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `full_name`" do
+          result = perform
+
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/example62_spec.rb
+++ b/spec/examples/usual/example62_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Example62 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[full_name gender],
+                     outputs: %i[first_name middle_name last_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected values" do
+          result = perform
+
+          expect(result.first_name).to eq("JOHN")
+          expect(result.middle_name).to eq("FITZGERALD")
+          expect(result.last_name).to eq("KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[full_name gender],
+                     outputs: %i[first_name middle_name last_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected values" do
+          result = perform
+
+          expect(result.first_name).to eq("JOHN")
+          expect(result.middle_name).to eq("FITZGERALD")
+          expect(result.last_name).to eq("KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/example62_spec.rb
+++ b/spec/examples/usual/example62_spec.rb
@@ -20,19 +20,20 @@ RSpec.describe Usual::Example62 do
 
     include_examples "check class info",
                      inputs: %i[first_name middle_name last_name gender],
-                     internals: %i[full_name gender],
-                     outputs: %i[first_name middle_name last_name]
+                     internals: %i[],
+                     outputs: %i[first_name middle_name last_name full_name]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         include_examples "success result class"
 
-        it "returns the expected values" do
+        it "returns the expected values", :aggregate_failures do
           result = perform
 
           expect(result.first_name).to eq("JOHN")
           expect(result.middle_name).to eq("FITZGERALD")
           expect(result.last_name).to eq("KENNEDY")
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
         end
       end
     end
@@ -79,19 +80,20 @@ RSpec.describe Usual::Example62 do
 
     include_examples "check class info",
                      inputs: %i[first_name middle_name last_name gender],
-                     internals: %i[full_name gender],
-                     outputs: %i[first_name middle_name last_name]
+                     internals: %i[],
+                     outputs: %i[first_name middle_name last_name full_name]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         include_examples "success result class"
 
-        it "returns the expected values" do
+        it "returns the expected values", :aggregate_failures do
           result = perform
 
           expect(result.first_name).to eq("JOHN")
           expect(result.middle_name).to eq("FITZGERALD")
           expect(result.last_name).to eq("KENNEDY")
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
         end
       end
     end

--- a/spec/examples/usual/example63_spec.rb
+++ b/spec/examples/usual/example63_spec.rb
@@ -20,19 +20,20 @@ RSpec.describe Usual::Example63 do
 
     include_examples "check class info",
                      inputs: %i[first_name middle_name last_name gender],
-                     internals: %i[full_name gender],
-                     outputs: %i[first_name middle_name last_name]
+                     internals: %i[],
+                     outputs: %i[first_name middle_name last_name full_name]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         include_examples "success result class"
 
-        it "returns the expected values" do
+        it "returns the expected values", :aggregate_failures do
           result = perform
 
           expect(result.first_name).to eq("JOHN")
           expect(result.middle_name).to eq("FITZGERALD")
           expect(result.last_name).to eq("KENNEDY")
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
         end
       end
     end
@@ -79,19 +80,20 @@ RSpec.describe Usual::Example63 do
 
     include_examples "check class info",
                      inputs: %i[first_name middle_name last_name gender],
-                     internals: %i[full_name gender],
-                     outputs: %i[first_name middle_name last_name]
+                     internals: %i[],
+                     outputs: %i[first_name middle_name last_name full_name]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         include_examples "success result class"
 
-        it "returns the expected values" do
+        it "returns the expected values", :aggregate_failures do
           result = perform
 
           expect(result.first_name).to eq("JOHN")
           expect(result.middle_name).to eq("FITZGERALD")
           expect(result.last_name).to eq("KENNEDY")
+          expect(result.full_name).to eq("JOHN FITZGERALD KENNEDY")
         end
       end
     end

--- a/spec/examples/usual/example63_spec.rb
+++ b/spec/examples/usual/example63_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Example63 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[full_name gender],
+                     outputs: %i[first_name middle_name last_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected values" do
+          result = perform
+
+          expect(result.first_name).to eq("JOHN")
+          expect(result.middle_name).to eq("FITZGERALD")
+          expect(result.last_name).to eq("KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        first_name: first_name,
+        middle_name: middle_name,
+        last_name: last_name,
+        gender: gender
+      }
+    end
+
+    let(:first_name) { "John" }
+    let(:middle_name) { "Fitzgerald" }
+    let(:last_name) { "Kennedy" }
+    let(:gender) { "Male" }
+
+    include_examples "check class info",
+                     inputs: %i[first_name middle_name last_name gender],
+                     internals: %i[full_name gender],
+                     outputs: %i[first_name middle_name last_name]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected values" do
+          result = perform
+
+          expect(result.first_name).to eq("JOHN")
+          expect(result.middle_name).to eq("FITZGERALD")
+          expect(result.last_name).to eq("KENNEDY")
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `first_name`" do
+        it_behaves_like "input required check", name: :first_name
+        it_behaves_like "input type check", name: :first_name, expected_type: String
+      end
+
+      context "when `middle_name`" do
+        it_behaves_like "input required check", name: :middle_name
+        it_behaves_like "input type check", name: :middle_name, expected_type: String
+      end
+
+      context "when `last_name`" do
+        it_behaves_like "input required check", name: :last_name
+        it_behaves_like "input type check", name: :last_name, expected_type: String
+      end
+
+      context "when `gender`" do
+        it_behaves_like "input required check", name: :gender
+        it_behaves_like "input type check", name: :gender, expected_type: String
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
outputs.full_name = inputs.only(:first_name, :middle_name, :last_name).values.compact.join(" ")
```

```ruby
outputs.full_name = inputs.except(:gender).values.compact.join(" ")
```