### PR TITLE
Update libraries from 12.12.2023

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     fileutils (1.7.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -60,7 +60,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbs (3.1.3)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -75,7 +75,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.57.2)
+    rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -83,7 +83,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -149,4 +149,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.4.12
+   2.4.17

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -2,7 +2,7 @@
 sources:
 - type: git
   name: ruby/gem_rbs_collection
-  revision: 25286c51a19927f28623aee3cd36655f902399ba
+  revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
   remote: https://github.com/ruby/gem_rbs_collection.git
   repo_dir: gems
 path: ".gem_rbs_collection"
@@ -12,7 +12,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -20,7 +20,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -36,7 +36,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -44,7 +44,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -72,7 +72,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -84,7 +84,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -112,7 +112,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -120,7 +120,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -128,7 +128,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -136,7 +136,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -144,7 +144,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -156,7 +156,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -164,7 +164,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -188,7 +188,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -204,7 +204,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 25286c51a19927f28623aee3cd36655f902399ba
+    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock


### PR DESCRIPTION
- [x] json 2.6.3 → 2.7.1 [diff](https://my.diffend.io/gems/json/2.6.3/2.7.1) [changelog](https://github.com/flori/json/blob/master/CHANGES.md)
- [x] regexp_parser 2.8.2 → 2.8.3 [diff](https://my.diffend.io/gems/regexp_parser/2.8.2/2.8.3) [changelog](https://github.com/ammar/regexp_parser/blob/master/CHANGELOG.md)
- [x] rubocop 1.57.2 → 1.59.0 [diff](https://my.diffend.io/gems/rubocop/1.57.2/1.59.0) [changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md)
