### PR TITLE
Update libraries from 10.01.2024

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,11 +1,15 @@
-name: "RuboCop"
+name: RuboCop
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - v1-stable
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches:
+      - main
+      - v1-stable
 
 jobs:
   rubocop:
@@ -18,12 +22,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # If running on a self-hosted runner, check it meets the requirements
     # listed at https://github.com/ruby/setup-ruby#using-self-hosted-runners
     - name: Set up Ruby
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
       with:
         ruby-version: 2.7
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
 
     # This step is not necessary if you add the gem to your Gemfile
     - name: Install Code Scanning integration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     minitest (5.20.0)
     mutex_m (0.2.0)
     parallel (1.24.0)
-    parser (3.2.2.4)
+    parser (3.3.0.2)
       ast (~> 2.4.1)
       racc
     pry (0.14.2)
@@ -60,7 +60,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbs (3.1.3)
-    regexp_parser (2.8.3)
+    regexp_parser (2.9.0)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -88,16 +88,16 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.19.0)
+    rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.24.0)
-      rubocop (~> 1.33)
-    rubocop-performance (1.20.0)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.25.0)
+    rubocop-rspec (2.26.1)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
@@ -149,4 +149,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.4.17
+   2.5.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,4 +149,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.5.1
+   2.5.4


### PR DESCRIPTION
- [x] parser 3.2.2.4 → 3.3.0.2 [diff](https://my.diffend.io/gems/parser/3.2.2.4/3.3.0.2) [changelog](https://github.com/whitequark/parser/blob/v3.3.0.2/CHANGELOG.md)
- [x] regexp_parser 2.8.3 → 2.9.0 [diff](https://my.diffend.io/gems/regexp_parser/2.8.3/2.9.0) [changelog](https://github.com/ammar/regexp_parser/blob/master/CHANGELOG.md)
- [x] rubocop-capybara 2.19.0 → 2.20.0 [diff](https://my.diffend.io/gems/rubocop-capybara/2.19.0/2.20.0) [changelog](https://github.com/rubocop/rubocop-capybara/blob/main/CHANGELOG.md)
- [x] rubocop-factory_bot 2.24.0 → 2.25.1 [diff](https://my.diffend.io/gems/rubocop-factory_bot/2.24.0/2.25.1) [changelog](https://github.com/rubocop/rubocop-factory_bot/blob/master/CHANGELOG.md)
- [x] rubocop-performance 1.20.0 → 1.20.2 [diff](https://my.diffend.io/gems/rubocop-performance/1.20.0/1.20.2) [changelog](https://github.com/rubocop/rubocop-performance/blob/master/CHANGELOG.md)
- [x] rubocop-rspec 2.25.0 → 2.26.1 [diff](https://my.diffend.io/gems/rubocop-rspec/2.25.0/2.26.1) [changelog](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md)