### PR TITLE
Add support for `type` option for `fail!` method

### DIFF
--- a/examples/usual/fail/example3.rb
+++ b/examples/usual/fail/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module Fail
+    class Example3 < ApplicationService::Base
+      input :invoice_number, type: String
+
+      output :invoice_number, type: String
+
+      make :check_invoice_number!
+      make :assign_invoice_number
+
+      private
+
+      def check_invoice_number!
+        return if inputs.invoice_number.start_with?("AA")
+
+        fail!(
+          :validation,
+          message: "Invalid invoice number",
+          meta: {
+            invoice_number: inputs.invoice_number
+          }
+        )
+      end
+
+      def assign_invoice_number
+        outputs.invoice_number = inputs.invoice_number
+      end
+    end
+  end
+end

--- a/lib/servactory/actions/tools/runner.rb
+++ b/lib/servactory/actions/tools/runner.rb
@@ -92,6 +92,7 @@ module Servactory
 
         def rescue_no_method_error_with(exception:) # rubocop:disable Metrics/MethodLength
           raise @context.class.config.failure_class.new(
+            type: :base,
             message: I18n.t(
               "servactory.common.undefined_method.missing_name",
               service_class_name: @context.class.name,
@@ -109,6 +110,7 @@ module Servactory
 
         def rescue_name_error_with(method:)
           raise @context.class.config.failure_class.new(
+            type: :base,
             message: I18n.t(
               "servactory.common.undefined_local_variable_or_method",
               service_class_name: @context.class.name,

--- a/lib/servactory/context/workspace.rb
+++ b/lib/servactory/context/workspace.rb
@@ -32,8 +32,8 @@ module Servactory
         )
       end
 
-      def fail!(message:, meta: nil)
-        raise self.class.config.failure_class.new(message: message, meta: meta)
+      def fail!(type = :base, message:, meta: nil)
+        raise self.class.config.failure_class.new(type: type, message: message, meta: meta)
       end
 
       def fail_result!(service_result)

--- a/lib/servactory/context/workspace.rb
+++ b/lib/servactory/context/workspace.rb
@@ -78,6 +78,7 @@ module Servactory
 
       def call
         raise self.class.config.failure_class.new(
+          type: :base,
           message: I18n.t(
             "servactory.methods.call.not_used",
             service_class_name: self.class.name

--- a/lib/servactory/errors/failure.rb
+++ b/lib/servactory/errors/failure.rb
@@ -3,10 +3,12 @@
 module Servactory
   module Errors
     class Failure < Base
-      attr_reader :message,
+      attr_reader :type,
+                  :message,
                   :meta
 
-      def initialize(message:, meta: nil)
+      def initialize(type:, message:, meta: nil)
+        @type = type
         @message = message
         @meta = meta
 

--- a/lib/servactory/result.rb
+++ b/lib/servactory/result.rb
@@ -62,6 +62,7 @@ module Servactory
 
     def rescue_no_method_error_with(exception:)
       raise @context.class.config.failure_class.new(
+        type: :base,
         message: I18n.t(
           "servactory.common.undefined_method.missing_name",
           service_class_name: @context.class.name,

--- a/sig/lib/servactory/context/workspace.rbs
+++ b/sig/lib/servactory/context/workspace.rbs
@@ -25,7 +25,7 @@ module Servactory
 
       def fail_input!: (Symbol input_name, message: String) -> Exception
 
-      def fail!: (message: String, meta: untyped?) -> Exception
+      def fail!: (Symbol type, message: String, meta: untyped?) -> Exception
 
       def fail_result!: (Result service_result) -> Exception
 

--- a/sig/lib/servactory/errors/failure.rbs
+++ b/sig/lib/servactory/errors/failure.rbs
@@ -1,10 +1,11 @@
 module Servactory
   module Errors
     class Failure < Base
+      attr_reader type: Symbol
       attr_reader message: String
       attr_reader meta: untyped
 
-      def initialize: (message: String, meta: untyped?) -> void
+      def initialize: (type: Symbol, message: String, meta: untyped?) -> void
     end
   end
 end

--- a/spec/examples/usual/basic/example8_spec.rb
+++ b/spec/examples/usual/basic/example8_spec.rb
@@ -36,12 +36,13 @@ RSpec.describe Usual::Basic::Example8 do
         describe "because wrong email" do
           let(:email) { "wrong@email.com" }
 
-          it "returns expected error" do
+          it "returns expected error", :aggregate_failures do
             expect { perform }.to(
-              raise_error(
-                ApplicationService::Errors::Failure,
-                "Authentication failed"
-              )
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::Failure)
+                expect(exception.type).to eq(:base)
+                expect(exception.message).to eq("Authentication failed")
+              end
             )
           end
         end
@@ -51,10 +52,11 @@ RSpec.describe Usual::Basic::Example8 do
 
           it "returns expected error" do
             expect { perform }.to(
-              raise_error(
-                ApplicationService::Errors::Failure,
-                "Authentication failed"
-              )
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::Failure)
+                expect(exception.type).to eq(:base)
+                expect(exception.message).to eq("Authentication failed")
+              end
             )
           end
         end
@@ -116,6 +118,7 @@ RSpec.describe Usual::Basic::Example8 do
 
             expect(result.error).to be_a(ApplicationService::Errors::Failure)
             expect(result.error).to an_object_having_attributes(
+              type: :base,
               message: "Authentication failed"
             )
           end
@@ -131,6 +134,7 @@ RSpec.describe Usual::Basic::Example8 do
 
             expect(result.error).to be_a(ApplicationService::Errors::Failure)
             expect(result.error).to an_object_having_attributes(
+              type: :base,
               message: "Authentication failed"
             )
           end

--- a/spec/examples/usual/conditions/example5_spec.rb
+++ b/spec/examples/usual/conditions/example5_spec.rb
@@ -32,12 +32,13 @@ RSpec.describe Usual::Conditions::Example5 do
         describe "because invalid invoice number" do
           let(:invoice_number) { "BB-7650AE" }
 
-          it "returns expected error" do
+          it "returns expected error", :aggregate_failures do
             expect { perform }.to(
-              raise_error(
-                ApplicationService::Errors::Failure,
-                "Invalid invoice number"
-              )
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::Failure)
+                expect(exception.type).to eq(:base)
+                expect(exception.message).to eq("Invalid invoice number")
+              end
             )
           end
         end
@@ -90,6 +91,7 @@ RSpec.describe Usual::Conditions::Example5 do
 
             expect(result.error).to be_a(ApplicationService::Errors::Failure)
             expect(result.error).to an_object_having_attributes(
+              type: :base,
               message: "Invalid invoice number"
             )
           end

--- a/spec/examples/usual/fail/example1_spec.rb
+++ b/spec/examples/usual/fail/example1_spec.rb
@@ -32,12 +32,13 @@ RSpec.describe Usual::Fail::Example1 do
         describe "because invalid invoice number" do
           let(:invoice_number) { "BB-7650AE" }
 
-          it "returns expected error" do
+          it "returns expected error", :aggregate_failures do
             expect { perform }.to(
-              raise_error(
-                ApplicationService::Errors::Failure,
-                "Invalid invoice number"
-              )
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::Failure)
+                expect(exception.type).to eq(:base)
+                expect(exception.message).to eq("Invalid invoice number")
+              end
             )
           end
         end
@@ -90,6 +91,7 @@ RSpec.describe Usual::Fail::Example1 do
 
             expect(result.error).to be_a(ApplicationService::Errors::Failure)
             expect(result.error).to an_object_having_attributes(
+              type: :base,
               message: "Invalid invoice number"
             )
           end

--- a/spec/examples/usual/fail/example2_spec.rb
+++ b/spec/examples/usual/fail/example2_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Usual::Fail::Example2 do
             expect { perform }.to(
               raise_error do |exception|
                 expect(exception).to be_a(ApplicationService::Errors::Failure)
+                expect(exception.type).to eq(:base)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(invoice_number: "BB-7650AE")
               end
@@ -91,6 +92,7 @@ RSpec.describe Usual::Fail::Example2 do
 
             expect(result.error).to be_a(ApplicationService::Errors::Failure)
             expect(result.error).to an_object_having_attributes(
+              type: :base,
               message: "Invalid invoice number",
               meta: {
                 invoice_number: "BB-7650AE"

--- a/spec/examples/usual/fail/example3_spec.rb
+++ b/spec/examples/usual/fail/example3_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::Fail::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::Failure)
+                expect(exception.type).to eq(:validation)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          include_examples "failure result class"
+
+          it "returns the expected value in `errors`", :aggregate_failures do
+            result = perform
+
+            expect(result.error).to be_a(ApplicationService::Errors::Failure)
+            expect(result.error).to an_object_having_attributes(
+              type: :validation,
+              message: "Invalid invoice number",
+              meta: {
+                invoice_number: "BB-7650AE"
+              }
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/stage/example12_spec.rb
+++ b/spec/examples/usual/stage/example12_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Usual::Stage::Example12 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns the expected value in `first_id`" do
+        it "returns expected error", :aggregate_failures do
           expect { perform }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "rollback with bad number"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to eq("rollback with bad number")
+            end
           )
         end
       end
@@ -40,6 +41,7 @@ RSpec.describe Usual::Stage::Example12 do
 
           expect(result.error).to be_a(ApplicationService::Errors::Failure)
           expect(result.error).to an_object_having_attributes(
+            type: :base,
             message: "rollback with bad number"
           )
         end

--- a/spec/examples/usual/stage/example6_spec.rb
+++ b/spec/examples/usual/stage/example6_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Usual::Stage::Example6 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns the expected value in `first_id`" do
+        it "returns expected error", :aggregate_failures do
           expect { perform }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "rollback with bad number"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to eq("rollback with bad number")
+            end
           )
         end
       end
@@ -40,6 +41,7 @@ RSpec.describe Usual::Stage::Example6 do
 
           expect(result.error).to be_a(ApplicationService::Errors::Failure)
           expect(result.error).to an_object_having_attributes(
+            type: :base,
             message: "rollback with bad number"
           )
         end

--- a/spec/examples/wrong/basic/example10_spec.rb
+++ b/spec/examples/wrong/basic/example10_spec.rb
@@ -11,14 +11,15 @@ RSpec.describe Wrong::Basic::Example10 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns expected error" do
+        it "returns expected error", :aggregate_failures do
           result = perform
 
           expect { result.fake_value }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "[Wrong::Basic::Example10] Undefined method `fake_value` for `nil`"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to eq("[Wrong::Basic::Example10] Undefined method `fake_value` for `nil`")
+            end
           )
         end
       end
@@ -35,14 +36,15 @@ RSpec.describe Wrong::Basic::Example10 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns expected error" do
+        it "returns expected error", :aggregate_failures do
           result = perform
 
           expect { result.fake_value }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "[Wrong::Basic::Example10] Undefined method `fake_value` for `nil`"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to eq("[Wrong::Basic::Example10] Undefined method `fake_value` for `nil`")
+            end
           )
         end
       end

--- a/spec/examples/wrong/basic/example8_spec.rb
+++ b/spec/examples/wrong/basic/example8_spec.rb
@@ -11,12 +11,15 @@ RSpec.describe Wrong::Basic::Example8 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns expected error" do
+        it "returns expected error", :aggregate_failures do
           expect { perform }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "[Wrong::Basic::Example8] Nothing to perform. Use `make` or create a `call` method."
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to(
+                eq("[Wrong::Basic::Example8] Nothing to perform. Use `make` or create a `call` method.")
+              )
+            end
           )
         end
       end
@@ -40,6 +43,7 @@ RSpec.describe Wrong::Basic::Example8 do
 
           expect(result.error).to be_a(ApplicationService::Errors::Failure)
           expect(result.error).to an_object_having_attributes(
+            type: :base,
             message: "[Wrong::Basic::Example8] Nothing to perform. Use `make` or create a `call` method."
           )
         end

--- a/spec/examples/wrong/basic/example9_spec.rb
+++ b/spec/examples/wrong/basic/example9_spec.rb
@@ -19,12 +19,15 @@ RSpec.describe Wrong::Basic::Example9 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns expected error" do
+        it "returns expected error", :aggregate_failures do
           expect { perform }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "[Wrong::Basic::Example9] Undefined local variable or method `assign_invoice_number`"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to(
+                eq("[Wrong::Basic::Example9] Undefined local variable or method `assign_invoice_number`")
+              )
+            end
           )
         end
       end
@@ -63,6 +66,7 @@ RSpec.describe Wrong::Basic::Example9 do
 
           expect(result.error).to be_a(ApplicationService::Errors::Failure)
           expect(result.error).to an_object_having_attributes(
+            type: :base,
             message: "[Wrong::Basic::Example9] Undefined local variable or method `assign_invoice_number`"
           )
         end

--- a/spec/examples/wrong/fail/example1_spec.rb
+++ b/spec/examples/wrong/fail/example1_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Wrong::Fail::Example1 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns expected error" do
+        it "returns expected error", :aggregate_failures do
           expect { perform }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "Some error"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to eq("Some error")
+            end
           )
         end
       end
@@ -38,6 +39,7 @@ RSpec.describe Wrong::Fail::Example1 do
 
           expect(result.error).to be_a(ApplicationService::Errors::Failure)
           expect(result.error).to an_object_having_attributes(
+            type: :base,
             message: "Some error",
             meta: {
               some: :data

--- a/spec/examples/wrong/prepare/example4_spec.rb
+++ b/spec/examples/wrong/prepare/example4_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe Wrong::Prepare::Example4 do
 
     context "when the input arguments are valid" do
       describe "but the data required for work is invalid" do
-        it "returns expected error" do
+        it "returns expected error", :aggregate_failures do
           expect { perform }.to(
-            raise_error(
-              ApplicationService::Errors::Failure,
-              "[Wrong::Prepare::Example4] Undefined method `+` for `nil`"
-            )
+            raise_error do |exception|
+              expect(exception).to be_a(ApplicationService::Errors::Failure)
+              expect(exception.type).to eq(:base)
+              expect(exception.message).to eq("[Wrong::Prepare::Example4] Undefined method `+` for `nil`")
+            end
           )
         end
       end
@@ -63,6 +64,7 @@ RSpec.describe Wrong::Prepare::Example4 do
 
           expect(result.error).to be_a(ApplicationService::Errors::Failure)
           expect(result.error).to an_object_having_attributes(
+            type: :base,
             message: "[Wrong::Prepare::Example4] Undefined method `+` for `nil`"
           )
         end

--- a/spec/servactory/test_kit/result_spec.rb
+++ b/spec/servactory/test_kit/result_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Servactory::TestKit::Result do
     it :aggregate_failures do # rubocop:disable RSpec/RepeatedDescription
       result = described_class.as_failure(
         exception: Servactory::Errors::Failure.new(
+          type: :base,
           message: "Test error message"
         )
       )


### PR DESCRIPTION
```ruby
# The default value of `type` is `base`
fail!(message: "Invalid invoice number")
```

```ruby
fail!(:base, message: "Invalid invoice number")
```

```ruby
fail!(:validation, message: "User already exists")
```