### PR TITLE
[03.02.2024] Update libraries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2.2
+  TargetRubyVersion: 3.3.0
 
 Gemspec/DevelopmentDependencies:
   Enabled: pending

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.2)
+    activesupport (7.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -25,12 +25,12 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.5)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     csv (3.2.8)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     drb (2.2.0)
       ruby2_keywords
     ffi (1.16.3)
@@ -44,10 +44,10 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.0)
     method_source (1.0.0)
-    minitest (5.20.0)
+    minitest (5.21.2)
     mutex_m (0.2.0)
     parallel (1.24.0)
-    parser (3.3.0.2)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pry (0.14.2)
@@ -75,11 +75,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.59.0)
+    rubocop (1.60.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -119,7 +119,7 @@ GEM
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)
-    strscan (3.0.7)
+    strscan (3.0.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -2,7 +2,7 @@
 sources:
 - type: git
   name: ruby/gem_rbs_collection
-  revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+  revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
   remote: https://github.com/ruby/gem_rbs_collection.git
   repo_dir: gems
 path: ".gem_rbs_collection"
@@ -12,7 +12,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -20,7 +20,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -36,7 +36,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -44,7 +44,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -72,7 +72,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -84,7 +84,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -112,7 +112,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -120,7 +120,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -128,7 +128,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -136,7 +136,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: regexp_parser
@@ -144,7 +144,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -156,7 +156,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -164,7 +164,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: securerandom
@@ -188,7 +188,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -204,7 +204,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 20e6e0f0685139dbd29df50e03367e222aa5d1b8
+    revision: 846c09971455f0e144cef2f5a6c9fe6d8905d3e1
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/spec/examples/usual/basic/example8_spec.rb
+++ b/spec/examples/usual/basic/example8_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Usual::Basic::Example8 do
         describe "because wrong password" do
           let(:password) { "wrong_password" }
 
-          it "returns expected error" do
+          it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
                 expect(exception).to be_a(ApplicationService::Errors::Failure)


### PR DESCRIPTION
- [x] activesupport 7.1.2 → 7.1.3 [diff](https://my.diffend.io/gems/activesupport/7.1.2/7.1.3) [changelog](https://github.com/rails/rails/blob/v7.1.3/activesupport/CHANGELOG.md#rails-713-january-16-2024)
- [x] bigdecimal 3.1.5 → 3.1.6 [diff](https://my.diffend.io/gems/bigdecimal/3.1.5/3.1.6)
- [x] concurrent-ruby 1.2.2 → 1.2.3 [diff](https://my.diffend.io/gems/concurrent-ruby/1.2.2/1.2.3) [changelog](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md#release-v123-16-jan-2024)
- [x] diff-lcs 1.5.0 → 1.5.1 [diff](https://my.diffend.io/gems/diff-lcs/1.5.0/1.5.1)
- [x] minitest 5.20.0 → 5.21.2 [diff](https://my.diffend.io/gems/minitest/5.20.0/5.21.2) [changelog](https://github.com/minitest/minitest/blob/master/History.rdoc#5212--2024-01-17-)
- [x] parser 3.3.0.2 → 3.3.0.5 [diff](https://my.diffend.io/gems/parser/3.3.0.2/3.3.0.5) [changelog](https://github.com/whitequark/parser/blob/v3.3.0.5/CHANGELOG.md)
- [x] rubocop 1.59.0 → 1.60.2 [diff](https://my.diffend.io/gems/rubocop/1.59.0/1.60.2) [changelog](https://github.com/rubocop/rubocop/releases/tag/v1.60.2)
- [x] strscan 3.0.7 → 3.0.9 [diff](https://my.diffend.io/gems/strscan/3.0.7/3.0.9)