### PR TITLE
Add support for `meta` option for `fail_input!`, `fail_internal!` and `fail_output!` methods

### DIFF
--- a/examples/usual/fail_input/example1.rb
+++ b/examples/usual/fail_input/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module FailInput
+    class Example1 < ApplicationService::Base
+      input :invoice_number, type: String
+
+      output :invoice_number, type: String
+
+      make :check_input_invoice_number!
+      make :assign_output_invoice_number
+
+      private
+
+      def check_input_invoice_number!
+        return if inputs.invoice_number.start_with?("AA")
+
+        fail_input!(
+          :invoice_number,
+          message: "Invalid invoice number",
+          meta: {
+            received_invoice_number: inputs.invoice_number
+          }
+        )
+      end
+
+      def assign_output_invoice_number
+        outputs.invoice_number = inputs.invoice_number
+      end
+    end
+  end
+end

--- a/examples/usual/fail_internal/example1.rb
+++ b/examples/usual/fail_internal/example1.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Usual
+  module FailInternal
+    class Example1 < ApplicationService::Base
+      input :invoice_number, type: String
+
+      internal :invoice_number, type: String
+
+      output :invoice_number, type: String
+
+      make :assign_internal_invoice_number
+      make :check_internal_invoice_number!
+      make :assign_output_invoice_number
+
+      private
+
+      def assign_internal_invoice_number
+        internals.invoice_number = inputs.invoice_number
+      end
+
+      def check_internal_invoice_number!
+        return if internals.invoice_number.start_with?("AA")
+
+        fail_internal!(
+          :invoice_number,
+          message: "Invalid invoice number",
+          meta: {
+            received_invoice_number: internals.invoice_number
+          }
+        )
+      end
+
+      def assign_output_invoice_number
+        outputs.invoice_number = internals.invoice_number
+      end
+    end
+  end
+end

--- a/examples/usual/fail_output/example1.rb
+++ b/examples/usual/fail_output/example1.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Usual
+  module FailOutput
+    class Example1 < ApplicationService::Base
+      input :invoice_number, type: String
+
+      internal :invoice_number, type: String
+
+      output :invoice_number, type: String
+
+      make :assign_internal_invoice_number
+      make :assign_output_invoice_number
+      make :check_output_invoice_number!
+
+      private
+
+      def assign_internal_invoice_number
+        internals.invoice_number = inputs.invoice_number
+      end
+
+      def assign_output_invoice_number
+        outputs.invoice_number = internals.invoice_number
+      end
+
+      def check_output_invoice_number!
+        return if outputs.invoice_number.start_with?("AA")
+
+        fail_output!(
+          :invoice_number,
+          message: "Invalid invoice number",
+          meta: {
+            received_invoice_number: outputs.invoice_number
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/servactory/context/workspace.rb
+++ b/lib/servactory/context/workspace.rb
@@ -29,24 +29,27 @@ module Servactory
         raise self.class.config.success_class.new(context: self)
       end
 
-      def fail_input!(input_name, message:)
+      def fail_input!(input_name, message:, meta: nil)
         raise self.class.config.input_error_class.new(
           input_name: input_name,
-          message: message
+          message: message,
+          meta: meta
         )
       end
 
-      def fail_internal!(internal_name, message:)
+      def fail_internal!(internal_name, message:, meta: nil)
         raise self.class.config.internal_error_class.new(
           internal_name: internal_name,
-          message: message
+          message: message,
+          meta: meta
         )
       end
 
-      def fail_output!(output_name, message:)
+      def fail_output!(output_name, message:, meta: nil)
         raise self.class.config.output_error_class.new(
           output_name: output_name,
-          message: message
+          message: message,
+          meta: meta
         )
       end
 

--- a/lib/servactory/errors/input_error.rb
+++ b/lib/servactory/errors/input_error.rb
@@ -4,11 +4,13 @@ module Servactory
   module Errors
     class InputError < Servactory::Exceptions::Base
       attr_reader :message,
-                  :input_name
+                  :input_name,
+                  :meta
 
-      def initialize(message:, input_name: nil)
+      def initialize(message:, input_name: nil, meta: nil)
         @message = message
         @input_name = input_name&.to_sym
+        @meta = meta
 
         super(message)
       end

--- a/lib/servactory/errors/internal_error.rb
+++ b/lib/servactory/errors/internal_error.rb
@@ -4,11 +4,13 @@ module Servactory
   module Errors
     class InternalError < Servactory::Exceptions::Base
       attr_reader :message,
-                  :internal_name
+                  :internal_name,
+                  :meta
 
-      def initialize(message:, internal_name: nil)
+      def initialize(message:, internal_name: nil, meta: nil)
         @message = message
         @internal_name = internal_name&.to_sym
+        @meta = meta
 
         super(message)
       end

--- a/lib/servactory/errors/output_error.rb
+++ b/lib/servactory/errors/output_error.rb
@@ -4,11 +4,13 @@ module Servactory
   module Errors
     class OutputError < Servactory::Exceptions::Base
       attr_reader :message,
-                  :output_name
+                  :output_name,
+                  :meta
 
-      def initialize(message:, output_name: nil)
+      def initialize(message:, output_name: nil, meta: nil)
         @message = message
         @output_name = output_name&.to_sym
+        @meta = meta
 
         super(message)
       end

--- a/lib/servactory/exceptions/input.rb
+++ b/lib/servactory/exceptions/input.rb
@@ -4,11 +4,13 @@ module Servactory
   module Exceptions
     class Input < Base
       attr_reader :message,
-                  :input_name
+                  :input_name,
+                  :meta
 
-      def initialize(message:, input_name: nil)
+      def initialize(message:, input_name: nil, meta: nil)
         @message = message
         @input_name = input_name&.to_sym
+        @meta = meta
 
         super(message)
       end

--- a/lib/servactory/exceptions/internal.rb
+++ b/lib/servactory/exceptions/internal.rb
@@ -4,11 +4,13 @@ module Servactory
   module Exceptions
     class Internal < Base
       attr_reader :message,
-                  :internal_name
+                  :internal_name,
+                  :meta
 
-      def initialize(message:, internal_name: nil)
+      def initialize(message:, internal_name: nil, meta: nil)
         @message = message
         @internal_name = internal_name&.to_sym
+        @meta = meta
 
         super(message)
       end

--- a/lib/servactory/exceptions/output.rb
+++ b/lib/servactory/exceptions/output.rb
@@ -4,11 +4,13 @@ module Servactory
   module Exceptions
     class Output < Base
       attr_reader :message,
-                  :output_name
+                  :output_name,
+                  :meta
 
-      def initialize(message:, output_name: nil)
+      def initialize(message:, output_name: nil, meta: nil)
         @message = message
         @output_name = output_name&.to_sym
+        @meta = meta
 
         super(message)
       end

--- a/sig/lib/servactory/context/workspace.rbs
+++ b/sig/lib/servactory/context/workspace.rbs
@@ -25,11 +25,11 @@ module Servactory
 
       def success!: () -> Exception
 
-      def fail_input!: (Symbol input_name, message: String) -> Exception
+      def fail_input!: (Symbol input_name, message: String, meta: untyped?) -> Exception
 
-      def fail_internal!: (Symbol internal_name, message: String) -> Exception
+      def fail_internal!: (Symbol internal_name, message: String, meta: untyped?) -> Exception
 
-      def fail_output!: (Symbol output_name, message: String) -> Exception
+      def fail_output!: (Symbol output_name, message: String, meta: untyped?) -> Exception
 
       def fail!: (Symbol type, message: String, meta: untyped?) -> Exception
 

--- a/sig/lib/servactory/errors/input_error.rbs
+++ b/sig/lib/servactory/errors/input_error.rbs
@@ -3,8 +3,9 @@ module Servactory
     class InputError < Base
       attr_reader message: String
       attr_reader input_name: Symbol?
+      attr_reader meta: untyped?
 
-      def initialize: (message: String, input_name: Symbol?) -> void
+      def initialize: (message: String, input_name: Symbol?, meta: untyped?) -> void
     end
   end
 end

--- a/sig/lib/servactory/errors/internal_error.rbs
+++ b/sig/lib/servactory/errors/internal_error.rbs
@@ -3,8 +3,9 @@ module Servactory
     class InternalError < Base
       attr_reader message: String
       attr_reader internal_name: Symbol?
+      attr_reader meta: untyped?
 
-      def initialize: (message: String, internal_name: Symbol?) -> void
+      def initialize: (message: String, internal_name: Symbol?, meta: untyped?) -> void
     end
   end
 end

--- a/sig/lib/servactory/errors/output_error.rbs
+++ b/sig/lib/servactory/errors/output_error.rbs
@@ -3,8 +3,9 @@ module Servactory
     class OutputError < Base
       attr_reader message: String
       attr_reader output_name: Symbol?
+      attr_reader meta: untyped?
 
-      def initialize: (message: String, output_name: Symbol?) -> void
+      def initialize: (message: String, output_name: Symbol?, meta: untyped?) -> void
     end
   end
 end

--- a/spec/examples/usual/fail_input/example1_spec.rb
+++ b/spec/examples/usual/fail_input/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::FailInput::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::InputError)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::InputError)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/fail_input/example1_spec.rb
+++ b/spec/examples/usual/fail_input/example1_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Usual::FailInput::Example1 do
           it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
-                expect(exception).to be_a(ApplicationService::Errors::InputError)
+                expect(exception).to be_a(ApplicationService::Exceptions::Input)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
               end
@@ -87,7 +87,7 @@ RSpec.describe Usual::FailInput::Example1 do
           it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
-                expect(exception).to be_a(ApplicationService::Errors::InputError)
+                expect(exception).to be_a(ApplicationService::Exceptions::Input)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
               end

--- a/spec/examples/usual/fail_internal/example1_spec.rb
+++ b/spec/examples/usual/fail_internal/example1_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Usual::FailInternal::Example1 do
           it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
-                expect(exception).to be_a(ApplicationService::Errors::InternalError)
+                expect(exception).to be_a(ApplicationService::Exceptions::Internal)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
               end
@@ -87,7 +87,7 @@ RSpec.describe Usual::FailInternal::Example1 do
           it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
-                expect(exception).to be_a(ApplicationService::Errors::InternalError)
+                expect(exception).to be_a(ApplicationService::Exceptions::Internal)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
               end

--- a/spec/examples/usual/fail_internal/example1_spec.rb
+++ b/spec/examples/usual/fail_internal/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::FailInternal::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[invoice_number],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::InternalError)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[invoice_number],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::InternalError)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/fail_output/example1_spec.rb
+++ b/spec/examples/usual/fail_output/example1_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Usual::FailOutput::Example1 do
           it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
-                expect(exception).to be_a(ApplicationService::Errors::OutputError)
+                expect(exception).to be_a(ApplicationService::Exceptions::Output)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
               end
@@ -87,7 +87,7 @@ RSpec.describe Usual::FailOutput::Example1 do
           it "returns expected error", :aggregate_failures do
             expect { perform }.to(
               raise_error do |exception|
-                expect(exception).to be_a(ApplicationService::Errors::OutputError)
+                expect(exception).to be_a(ApplicationService::Exceptions::Output)
                 expect(exception.message).to eq("Invalid invoice number")
                 expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
               end

--- a/spec/examples/usual/fail_output/example1_spec.rb
+++ b/spec/examples/usual/fail_output/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::FailOutput::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[invoice_number],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::OutputError)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        invoice_number: invoice_number
+      }
+    end
+
+    let(:invoice_number) { "AA-7650AE" }
+
+    include_examples "check class info",
+                     inputs: %i[invoice_number],
+                     internals: %i[invoice_number],
+                     outputs: %i[invoice_number]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        it "returns the expected value in `invoice_number`" do
+          result = perform
+
+          expect(result.invoice_number).to eq("AA-7650AE")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because invalid invoice number" do
+          let(:invoice_number) { "BB-7650AE" }
+
+          it "returns expected error", :aggregate_failures do
+            expect { perform }.to(
+              raise_error do |exception|
+                expect(exception).to be_a(ApplicationService::Errors::OutputError)
+                expect(exception.message).to eq("Invalid invoice number")
+                expect(exception.meta).to match(received_invoice_number: "BB-7650AE")
+              end
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `invoice_number`" do
+        it_behaves_like "input required check", name: :invoice_number
+        it_behaves_like "input type check", name: :invoice_number, expected_type: String
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
fail_input!(
  :invoice_number,
  message: "Invalid invoice number",
  meta: {
    received_invoice_number: inputs.invoice_number
  }
)
```

```ruby
fail_internal!(
  :invoice_number,
  message: "Invalid invoice number",
  meta: {
    received_invoice_number: internals.invoice_number
  }
)
```

```ruby
fail_output!(
  :invoice_number,
  message: "Invalid invoice number",
  meta: {
    received_invoice_number: outputs.invoice_number
  }
)
```