### PR TITLE
Add `email` format for dynamic option `format`

### DIFF
--- a/examples/usual/dynamic_options/format/email/basic/example1.rb
+++ b/examples/usual/dynamic_options/format/email/basic/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Basic
+          class Example1 < ApplicationService::Base
+            input :email, type: String, format: :email
+
+            output :email, type: String
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.email = "No Reply <#{inputs.email}>"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/basic/example2.rb
+++ b/examples/usual/dynamic_options/format/email/basic/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Basic
+          class Example2 < ApplicationService::Base
+            input :email, type: String
+
+            internal :email, type: String, check_format: :email
+
+            output :email, type: String
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.email = inputs.email
+            end
+
+            def assign_output
+              outputs.email = "No Reply <#{internals.email}>"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/basic/example3.rb
+++ b/examples/usual/dynamic_options/format/email/basic/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Basic
+          class Example3 < ApplicationService::Base
+            input :email, type: String
+
+            output :email, type: String, format: :email
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.email = inputs.email
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/is/example1.rb
+++ b/examples/usual/dynamic_options/format/email/is/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Is
+          class Example1 < ApplicationService::Base
+            input :email, type: String, format: { is: :email }
+
+            output :email, type: String
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.email = "No Reply <#{inputs.email}>"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/is/example2.rb
+++ b/examples/usual/dynamic_options/format/email/is/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Is
+          class Example2 < ApplicationService::Base
+            input :email, type: String
+
+            internal :email, type: String, check_format: { is: :email }
+
+            output :email, type: String
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.email = inputs.email
+            end
+
+            def assign_output
+              outputs.email = "No Reply <#{internals.email}>"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/is/example3.rb
+++ b/examples/usual/dynamic_options/format/email/is/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Is
+          class Example3 < ApplicationService::Base
+            input :email, type: String
+
+            output :email, type: String, format: { is: :email }
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.email = inputs.email
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/message/lambda/example1.rb
+++ b/examples/usual/dynamic_options/format/email/message/lambda/example1.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Message
+          module Lambda
+            class Example1 < ApplicationService::Base
+              input :email,
+                    type: String,
+                    format: {
+                      is: :email,
+                      message: lambda do |input:, value:, option_value:, **|
+                        "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
+                      end
+                    }
+
+              output :email, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = "No Reply <#{inputs.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/message/lambda/example2.rb
+++ b/examples/usual/dynamic_options/format/email/message/lambda/example2.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Message
+          module Lambda
+            class Example2 < ApplicationService::Base
+              input :email, type: String
+
+              internal :email,
+                       type: String,
+                       check_format: {
+                         is: :email,
+                         message: lambda do |internal:, value:, option_value:, **|
+                           "Value `#{value}` does not match the format of `#{option_value}` in `#{internal.name}`"
+                         end
+                       }
+
+              output :email, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.email = inputs.email
+              end
+
+              def assign_output
+                outputs.email = "No Reply <#{internals.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/message/lambda/example3.rb
+++ b/examples/usual/dynamic_options/format/email/message/lambda/example3.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Message
+          module Lambda
+            class Example3 < ApplicationService::Base
+              input :email, type: String
+
+              output :email,
+                     type: String,
+                     format: {
+                       is: :email,
+                       message: lambda do |output:, value:, option_value:, **|
+                         "Value `#{value}` does not match the format of `#{option_value}` in `#{output.name}`"
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = inputs.email
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/message/static/example1.rb
+++ b/examples/usual/dynamic_options/format/email/message/static/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Message
+          module Static
+            class Example1 < ApplicationService::Base
+              input :email,
+                    type: String,
+                    format: {
+                      is: :email,
+                      message: "Invalid email format"
+                    }
+
+              output :email, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = "No Reply <#{inputs.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/message/static/example2.rb
+++ b/examples/usual/dynamic_options/format/email/message/static/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Message
+          module Static
+            class Example2 < ApplicationService::Base
+              input :email, type: String
+
+              internal :email,
+                       type: String,
+                       check_format: {
+                         is: :email,
+                         message: "Invalid email format"
+                       }
+
+              output :email, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.email = inputs.email
+              end
+
+              def assign_output
+                outputs.email = "No Reply <#{internals.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/message/static/example3.rb
+++ b/examples/usual/dynamic_options/format/email/message/static/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Message
+          module Static
+            class Example3 < ApplicationService::Base
+              input :email, type: String
+
+              output :email,
+                     type: String,
+                     format: {
+                       is: :email,
+                       message: "Invalid email format"
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = inputs.email
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/properties/pattern/example1.rb
+++ b/examples/usual/dynamic_options/format/email/properties/pattern/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Properties
+          module Pattern
+            class Example1 < ApplicationService::Base
+              input :email,
+                    type: String,
+                    format: {
+                      is: :email,
+                      pattern: nil # This will disable the value checking based on the pattern
+                    }
+
+              output :email, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = "No Reply <#{inputs.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/properties/pattern/example2.rb
+++ b/examples/usual/dynamic_options/format/email/properties/pattern/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Properties
+          module Pattern
+            class Example2 < ApplicationService::Base
+              input :email, type: String
+
+              internal :email,
+                       type: String,
+                       check_format: {
+                         is: :email,
+                         pattern: nil # This will disable the value checking based on the pattern
+                       }
+
+              output :email, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.email = inputs.email
+              end
+
+              def assign_output
+                outputs.email = "No Reply <#{internals.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/properties/pattern/example3.rb
+++ b/examples/usual/dynamic_options/format/email/properties/pattern/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Properties
+          module Pattern
+            class Example3 < ApplicationService::Base
+              input :email, type: String
+
+              output :email,
+                     type: String,
+                     format: {
+                       is: :email,
+                       pattern: nil # This will disable the value checking based on the pattern
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = inputs.email
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/properties/validator/example1.rb
+++ b/examples/usual/dynamic_options/format/email/properties/validator/example1.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Properties
+          module Validator
+            class Example1 < ApplicationService::Base
+              input :email,
+                    type: String,
+                    format: {
+                      is: :email,
+                      pattern: nil, # This will disable the value checking based on the pattern
+                      validator: lambda do |value:|
+                        value.split(" at ").size == 2
+                      end
+                    }
+
+              output :email, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = "No Reply <#{inputs.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/properties/validator/example2.rb
+++ b/examples/usual/dynamic_options/format/email/properties/validator/example2.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Properties
+          module Validator
+            class Example2 < ApplicationService::Base
+              input :email, type: String
+
+              internal :email,
+                       type: String,
+                       check_format: {
+                         is: :email,
+                         pattern: nil, # This will disable the value checking based on the pattern
+                         validator: lambda do |value:|
+                           value.split(" at ").size == 2
+                         end
+                       }
+
+              output :email, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.email = inputs.email
+              end
+
+              def assign_output
+                outputs.email = "No Reply <#{internals.email}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/email/properties/validator/example3.rb
+++ b/examples/usual/dynamic_options/format/email/properties/validator/example3.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Email
+        module Properties
+          module Validator
+            class Example3 < ApplicationService::Base
+              input :email, type: String
+
+              output :email,
+                     type: String,
+                     format: {
+                       is: :email,
+                       pattern: nil, # This will disable the value checking based on the pattern
+                       validator: lambda do |value:|
+                         value.split(" at ").size == 2
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.email = inputs.email
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/servactory.rb
+++ b/lib/servactory.rb
@@ -4,6 +4,8 @@ require "zeitwerk"
 
 require "active_support/all"
 
+require "uri"
+
 loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   "dsl" => "DSL"

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -5,6 +5,10 @@ module Servactory
     module DynamicOptions
       class Format < Must
         FORMATS = {
+          email: {
+            pattern: URI::MailTo::EMAIL_REGEXP,
+            validator: ->(value:) { value.present? }
+          },
           date: {
             pattern: /^([0-9]{4})-?(1[0-2]|0[1-9])-?(3[01]|0[1-9]|[12][0-9])$/,
             validator: lambda do |value:|
@@ -14,6 +18,7 @@ module Servactory
             end
           }
         }.freeze
+        private_constant :FORMATS
 
         def self.setup(option_name = :format)
           new(option_name).must(:be_in_format)

--- a/spec/examples/usual/dynamic_options/format/email/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/basic/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Basic::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Basic::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Basic::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/basic/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Basic::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Basic::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Basic::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/basic/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Basic::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Basic::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Basic::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/is/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Is::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Is::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Is::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/is/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Is::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Is::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Is::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/is/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Is::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Is::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Is::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/message/lambda/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/message/lambda/example1_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Message::Lambda::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `noreply at servactory.com` does not match the format of `email` in `email`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `noreply at servactory.com` does not match the format of `email` in `email`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/message/lambda/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/message/lambda/example2_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Message::Lambda::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `noreply at servactory.com` does not match the format of `email` in `email`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `noreply at servactory.com` does not match the format of `email` in `email`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/message/lambda/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/message/lambda/example3_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Message::Lambda::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `noreply at servactory.com` does not match the format of `email` in `email`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `noreply at servactory.com` does not match the format of `email` in `email`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/message/static/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/message/static/example1_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Message::Static::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid email format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid email format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/message/static/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/message/static/example2_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Message::Static::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid email format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply@servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid email format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/message/static/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/message/static/example3_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Message::Static::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid email format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply@servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply@servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply at servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid email format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/properties/pattern/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Properties::Pattern::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Properties::Pattern::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Properties::Pattern::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/properties/pattern/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/properties/pattern/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Properties::Pattern::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Properties::Pattern::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Properties::Pattern::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/properties/pattern/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/properties/pattern/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Properties::Pattern::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply at servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Properties::Pattern::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply at servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Properties::Pattern::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/properties/validator/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/properties/validator/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Properties::Validator::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply@servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Properties::Validator::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply@servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Email::Properties::Validator::Example1] " \
+                "Input `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/properties/validator/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/properties/validator/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Properties::Validator::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply@servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Properties::Validator::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[email],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("No Reply <noreply at servactory.com>")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply@servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Email::Properties::Validator::Example2] " \
+                "Internal attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/email/properties/validator/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/email/properties/validator/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Email::Properties::Validator::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply at servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply@servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Properties::Validator::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        email: email
+      }
+    end
+
+    let(:email) { "noreply at servactory.com" }
+
+    include_examples "check class info",
+                     inputs: %i[email],
+                     internals: %i[],
+                     outputs: %i[email]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.email?).to be(true)
+          expect(result.email).to eq("noreply at servactory.com")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:email) { "noreply@servactory.com" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Email::Properties::Validator::Example3] " \
+                "Output attribute `email` does not match `email` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :email
+
+        it_behaves_like "input type check", name: :email, expected_type: String
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
input :email, type: String, format: :email

input :email,
      type: String,
      format: {
        is: :email,
        message: lambda do |input:, value:, option_value:, **|
          "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
        end
      }
```