### PR TITLE
Add `password` format for dynamic option `format`

### DIFF
--- a/examples/usual/dynamic_options/format/password/basic/example1.rb
+++ b/examples/usual/dynamic_options/format/password/basic/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Basic
+          class Example1 < ApplicationService::Base
+            input :password, type: String, format: :password
+
+            output :password, type: String
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.password = inputs.password
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/basic/example2.rb
+++ b/examples/usual/dynamic_options/format/password/basic/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Basic
+          class Example2 < ApplicationService::Base
+            input :password, type: String
+
+            internal :password, type: String, check_format: :password
+
+            output :password, type: String
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.password = inputs.password
+            end
+
+            def assign_output
+              outputs.password = internals.password
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/basic/example3.rb
+++ b/examples/usual/dynamic_options/format/password/basic/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Basic
+          class Example3 < ApplicationService::Base
+            input :password, type: String
+
+            output :password, type: String, format: :password
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.password = inputs.password
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/is/example1.rb
+++ b/examples/usual/dynamic_options/format/password/is/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Is
+          class Example1 < ApplicationService::Base
+            input :password, type: String, format: { is: :password }
+
+            output :password, type: String
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.password = inputs.password
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/is/example2.rb
+++ b/examples/usual/dynamic_options/format/password/is/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Is
+          class Example2 < ApplicationService::Base
+            input :password, type: String
+
+            internal :password, type: String, check_format: { is: :password }
+
+            output :password, type: String
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.password = inputs.password
+            end
+
+            def assign_output
+              outputs.password = internals.password
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/is/example3.rb
+++ b/examples/usual/dynamic_options/format/password/is/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Is
+          class Example3 < ApplicationService::Base
+            input :password, type: String
+
+            output :password, type: String, format: { is: :password }
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.password = inputs.password
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/message/lambda/example1.rb
+++ b/examples/usual/dynamic_options/format/password/message/lambda/example1.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Message
+          module Lambda
+            class Example1 < ApplicationService::Base
+              input :password,
+                    type: String,
+                    format: {
+                      is: :password,
+                      message: lambda do |input:, value:, option_value:, **|
+                        "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
+                      end
+                    }
+
+              output :password, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/message/lambda/example2.rb
+++ b/examples/usual/dynamic_options/format/password/message/lambda/example2.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Message
+          module Lambda
+            class Example2 < ApplicationService::Base
+              input :password, type: String
+
+              internal :password,
+                       type: String,
+                       check_format: {
+                         is: :password,
+                         message: lambda do |internal:, value:, option_value:, **|
+                           "Value `#{value}` does not match the format of `#{option_value}` in `#{internal.name}`"
+                         end
+                       }
+
+              output :password, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.password = inputs.password
+              end
+
+              def assign_output
+                outputs.password = internals.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/message/lambda/example3.rb
+++ b/examples/usual/dynamic_options/format/password/message/lambda/example3.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Message
+          module Lambda
+            class Example3 < ApplicationService::Base
+              input :password, type: String
+
+              output :password,
+                     type: String,
+                     format: {
+                       is: :password,
+                       message: lambda do |output:, value:, option_value:, **|
+                         "Value `#{value}` does not match the format of `#{option_value}` in `#{output.name}`"
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/message/static/example1.rb
+++ b/examples/usual/dynamic_options/format/password/message/static/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Message
+          module Static
+            class Example1 < ApplicationService::Base
+              input :password,
+                    type: String,
+                    format: {
+                      is: :password,
+                      message: "Invalid date format"
+                    }
+
+              output :password, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/message/static/example2.rb
+++ b/examples/usual/dynamic_options/format/password/message/static/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Message
+          module Static
+            class Example2 < ApplicationService::Base
+              input :password, type: String
+
+              internal :password,
+                       type: String,
+                       check_format: {
+                         is: :password,
+                         message: "Invalid date format"
+                       }
+
+              output :password, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.password = inputs.password
+              end
+
+              def assign_output
+                outputs.password = internals.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/message/static/example3.rb
+++ b/examples/usual/dynamic_options/format/password/message/static/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Message
+          module Static
+            class Example3 < ApplicationService::Base
+              input :password, type: String
+
+              output :password,
+                     type: String,
+                     format: {
+                       is: :password,
+                       message: "Invalid date format"
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/properties/pattern/example1.rb
+++ b/examples/usual/dynamic_options/format/password/properties/pattern/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Properties
+          module Pattern
+            class Example1 < ApplicationService::Base
+              input :password,
+                    type: String,
+                    format: {
+                      is: :password,
+                      pattern: nil # This will disable the value checking based on the pattern
+                    }
+
+              output :password, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/properties/pattern/example2.rb
+++ b/examples/usual/dynamic_options/format/password/properties/pattern/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Properties
+          module Pattern
+            class Example2 < ApplicationService::Base
+              input :password, type: String
+
+              internal :password,
+                       type: String,
+                       check_format: {
+                         is: :password,
+                         pattern: nil # This will disable the value checking based on the pattern
+                       }
+
+              output :password, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.password = inputs.password
+              end
+
+              def assign_output
+                outputs.password = internals.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/properties/pattern/example3.rb
+++ b/examples/usual/dynamic_options/format/password/properties/pattern/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Properties
+          module Pattern
+            class Example3 < ApplicationService::Base
+              input :password, type: String
+
+              output :password,
+                     type: String,
+                     format: {
+                       is: :password,
+                       pattern: nil # This will disable the value checking based on the pattern
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/properties/validator/example1.rb
+++ b/examples/usual/dynamic_options/format/password/properties/validator/example1.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Properties
+          module Validator
+            class Example1 < ApplicationService::Base
+              input :password,
+                    type: String,
+                    format: {
+                      is: :password,
+                      pattern: nil, # This will disable the value checking based on the pattern
+                      validator: lambda do |value:|
+                        value.size >= 9
+                      end
+                    }
+
+              output :password, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/properties/validator/example2.rb
+++ b/examples/usual/dynamic_options/format/password/properties/validator/example2.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Properties
+          module Validator
+            class Example2 < ApplicationService::Base
+              input :password, type: String
+
+              internal :password,
+                       type: String,
+                       check_format: {
+                         is: :password,
+                         pattern: nil, # This will disable the value checking based on the pattern
+                         validator: lambda do |value:|
+                           value.size >= 9
+                         end
+                       }
+
+              output :password, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.password = inputs.password
+              end
+
+              def assign_output
+                outputs.password = internals.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/password/properties/validator/example3.rb
+++ b/examples/usual/dynamic_options/format/password/properties/validator/example3.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Password
+        module Properties
+          module Validator
+            class Example3 < ApplicationService::Base
+              input :password, type: String
+
+              output :password,
+                     type: String,
+                     format: {
+                       is: :password,
+                       pattern: nil, # This will disable the value checking based on the pattern
+                       validator: lambda do |value:|
+                         value.size >= 9
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.password = inputs.password
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -12,6 +12,14 @@ module Servactory
             rescue Date::Error
               false
             end
+          },
+          password: {
+            # NOTE: Pattern 4 » https://dev.to/rasaf_ibrahim/write-regex-password-validation-like-a-pro-5175
+            #       Password must contain one digit from 1 to 9, one lowercase letter, one
+            #       uppercase letter, and one underscore, and it must be 8-16 characters long.
+            #       Usage of any other special character and usage of space is optional.
+            pattern: /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,16}$/,
+            validator: ->(value:) { value.present? }
           }
         }.freeze
 

--- a/spec/examples/usual/dynamic_options/format/password/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/basic/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Basic::Example1] " \
+                  "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Basic::Example1] " \
+                  "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/basic/example1_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example1 do
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Password::Basic::Example1] " \
-                  "Input `password` does not match `password` format"
+                "Input `password` does not match `password` format"
               )
             )
           end
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example1 do
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Password::Basic::Example1] " \
-                  "Input `password` does not match `password` format"
+                "Input `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/basic/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Basic::Example2] " \
+                  "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Basic::Example2] " \
+                  "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/basic/example2_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example2 do
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Password::Basic::Example2] " \
-                  "Internal attribute `password` does not match `password` format"
+                "Internal attribute `password` does not match `password` format"
               )
             )
           end
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example2 do
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Password::Basic::Example2] " \
-                  "Internal attribute `password` does not match `password` format"
+                "Internal attribute `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/basic/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Basic::Example3] " \
+                  "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Basic::Example3] " \
+                  "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/basic/example3_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example3 do
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Password::Basic::Example3] " \
-                  "Output attribute `password` does not match `password` format"
+                "Output attribute `password` does not match `password` format"
               )
             )
           end
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Basic::Example3 do
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Password::Basic::Example3] " \
-                  "Output attribute `password` does not match `password` format"
+                "Output attribute `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/is/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Is::Example1] " \
+                  "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Is::Example1] " \
+                  "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/is/example1_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example1 do
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Password::Is::Example1] " \
-                  "Input `password` does not match `password` format"
+                "Input `password` does not match `password` format"
               )
             )
           end
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example1 do
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Password::Is::Example1] " \
-                  "Input `password` does not match `password` format"
+                "Input `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/is/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Is::Example2] " \
+                  "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Is::Example2] " \
+                  "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/is/example2_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example2 do
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Password::Is::Example2] " \
-                  "Internal attribute `password` does not match `password` format"
+                "Internal attribute `password` does not match `password` format"
               )
             )
           end
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example2 do
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Password::Is::Example2] " \
-                  "Internal attribute `password` does not match `password` format"
+                "Internal attribute `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/is/example3_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example3 do
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Password::Is::Example3] " \
-                  "Output attribute `password` does not match `password` format"
+                "Output attribute `password` does not match `password` format"
               )
             )
           end
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example3 do
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Password::Is::Example3] " \
-                  "Output attribute `password` does not match `password` format"
+                "Output attribute `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/is/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Is::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Is::Example3] " \
+                  "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Is::Example3] " \
+                  "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/message/lambda/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/message/lambda/example1_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Message::Lambda::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `my-best-password` does not match the format of `password` in `password`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `my-best-password` does not match the format of `password` in `password`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/message/lambda/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/message/lambda/example2_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Message::Lambda::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `my-best-password` does not match the format of `password` in `password`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `my-best-password` does not match the format of `password` in `password`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/message/lambda/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/message/lambda/example3_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Message::Lambda::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `my-best-password` does not match the format of `password` in `password`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `my-best-password` does not match the format of `password` in `password`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/message/static/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/message/static/example1_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Message::Static::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/message/static/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/message/static/example2_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Message::Static::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/message/static/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/message/static/example3_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Message::Static::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "~hUN`AgY=YpW.061" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("~hUN`AgY=YpW.061")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "my-best-password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/pattern/example1_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Pattern::Exa
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example1] " \
-                  "Input `password` does not match `password` format"
+                "Input `password` does not match `password` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/password/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/pattern/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Pattern::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example1] " \
+                "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example1] " \
+                  "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/properties/pattern/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/pattern/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Pattern::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example2] " \
+                "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example2] " \
+                "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/properties/pattern/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/pattern/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Pattern::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example3] " \
+                "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Properties::Pattern::Example3] " \
+                "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/properties/validator/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/validator/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Validator::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Properties::Validator::Example1] " \
+                "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Password::Properties::Validator::Example1] " \
+                "Input `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/properties/validator/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/validator/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Validator::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Properties::Validator::Example2] " \
+                "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[password],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Password::Properties::Validator::Example2] " \
+                "Internal attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/password/properties/validator/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/password/properties/validator/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Password::Properties::Validator::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Properties::Validator::Example3] " \
+                "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        password: password
+      }
+    end
+
+    let(:password) { "my-best-password" }
+
+    include_examples "check class info",
+                     inputs: %i[password],
+                     internals: %i[],
+                     outputs: %i[password]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.password?).to be(true)
+          expect(result.password).to eq("my-best-password")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:password) { "password" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Password::Properties::Validator::Example3] " \
+                "Output attribute `password` does not match `password` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :password
+
+        it_behaves_like "input type check", name: :password, expected_type: String
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
input :password, type: String, format: :password

input :password,
      type: String,
      format: {
        is: :password,
        message: lambda do |input:, value:, option_value:, **|
          "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
        end
      }
```