### PR TITLE
Add `datetime` format for dynamic option `format`

### DIFF
--- a/examples/usual/dynamic_options/format/date_time/basic/example1.rb
+++ b/examples/usual/dynamic_options/format/date_time/basic/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Basic
+          class Example1 < ApplicationService::Base
+            input :started_at, type: String, format: :datetime
+
+            output :started_at, type: ::DateTime
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.started_at = ::DateTime.parse(inputs.started_at)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/basic/example2.rb
+++ b/examples/usual/dynamic_options/format/date_time/basic/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Basic
+          class Example2 < ApplicationService::Base
+            input :started_at, type: String
+
+            internal :started_at, type: String, check_format: :datetime
+
+            output :started_at, type: ::DateTime
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.started_at = inputs.started_at
+            end
+
+            def assign_output
+              outputs.started_at = ::DateTime.parse(internals.started_at)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/basic/example3.rb
+++ b/examples/usual/dynamic_options/format/date_time/basic/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Basic
+          class Example3 < ApplicationService::Base
+            input :started_at, type: String
+
+            output :started_at, type: String, format: :datetime
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.started_at = inputs.started_at
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/is/example1.rb
+++ b/examples/usual/dynamic_options/format/date_time/is/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Is
+          class Example1 < ApplicationService::Base
+            input :started_at, type: String, format: { is: :datetime }
+
+            output :started_at, type: ::DateTime
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.started_at = ::DateTime.parse(inputs.started_at)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/is/example2.rb
+++ b/examples/usual/dynamic_options/format/date_time/is/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Is
+          class Example2 < ApplicationService::Base
+            input :started_at, type: String
+
+            internal :started_at, type: String, check_format: { is: :datetime }
+
+            output :started_at, type: ::DateTime
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.started_at = inputs.started_at
+            end
+
+            def assign_output
+              outputs.started_at = ::DateTime.parse(internals.started_at)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/is/example3.rb
+++ b/examples/usual/dynamic_options/format/date_time/is/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Is
+          class Example3 < ApplicationService::Base
+            input :started_at, type: String
+
+            output :started_at, type: String, format: { is: :datetime }
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.started_at = inputs.started_at
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/message/lambda/example1.rb
+++ b/examples/usual/dynamic_options/format/date_time/message/lambda/example1.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Message
+          module Lambda
+            class Example1 < ApplicationService::Base
+              input :started_at,
+                    type: String,
+                    format: {
+                      is: :datetime,
+                      message: lambda do |input:, value:, option_value:, **|
+                        "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
+                      end
+                    }
+
+              output :started_at, type: ::DateTime
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.started_at = ::DateTime.parse(inputs.started_at)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/message/lambda/example2.rb
+++ b/examples/usual/dynamic_options/format/date_time/message/lambda/example2.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Message
+          module Lambda
+            class Example2 < ApplicationService::Base
+              input :started_at, type: String
+
+              internal :started_at,
+                       type: String,
+                       check_format: {
+                         is: :datetime,
+                         message: lambda do |internal:, value:, option_value:, **|
+                           "Value `#{value}` does not match the format of `#{option_value}` in `#{internal.name}`"
+                         end
+                       }
+
+              output :started_at, type: ::DateTime
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.started_at = inputs.started_at
+              end
+
+              def assign_output
+                outputs.started_at = ::DateTime.parse(internals.started_at)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/message/lambda/example3.rb
+++ b/examples/usual/dynamic_options/format/date_time/message/lambda/example3.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Message
+          module Lambda
+            class Example3 < ApplicationService::Base
+              input :started_at, type: String
+
+              output :started_at,
+                     type: String,
+                     format: {
+                       is: :datetime,
+                       message: lambda do |output:, value:, option_value:, **|
+                         "Value `#{value}` does not match the format of `#{option_value}` in `#{output.name}`"
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.started_at = inputs.started_at
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/message/static/example1.rb
+++ b/examples/usual/dynamic_options/format/date_time/message/static/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Message
+          module Static
+            class Example1 < ApplicationService::Base
+              input :started_at,
+                    type: String,
+                    format: {
+                      is: :datetime,
+                      message: "Invalid datetime format"
+                    }
+
+              output :started_at, type: ::DateTime
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.started_at = ::DateTime.parse(inputs.started_at)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/message/static/example2.rb
+++ b/examples/usual/dynamic_options/format/date_time/message/static/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Message
+          module Static
+            class Example2 < ApplicationService::Base
+              input :started_at, type: String
+
+              internal :started_at,
+                       type: String,
+                       check_format: {
+                         is: :datetime,
+                         message: "Invalid datetime format"
+                       }
+
+              output :started_at, type: ::DateTime
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.started_at = inputs.started_at
+              end
+
+              def assign_output
+                outputs.started_at = ::DateTime.parse(internals.started_at)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/message/static/example3.rb
+++ b/examples/usual/dynamic_options/format/date_time/message/static/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Message
+          module Static
+            class Example3 < ApplicationService::Base
+              input :started_at, type: String
+
+              output :started_at,
+                     type: String,
+                     format: {
+                       is: :datetime,
+                       message: "Invalid datetime format"
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.started_at = inputs.started_at
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/properties/pattern/example1.rb
+++ b/examples/usual/dynamic_options/format/date_time/properties/pattern/example1.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Properties
+          module Pattern
+            class Example1 < ApplicationService::Base
+              # rubocop:disable Layout/LineLength
+              input :started_at,
+                    type: String,
+                    format: {
+                      is: :datetime,
+                      pattern: /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/
+                    }
+              # rubocop:enable Layout/LineLength
+
+              output :started_at, type: ::DateTime
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.started_at = ::DateTime.parse(inputs.started_at)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/properties/pattern/example2.rb
+++ b/examples/usual/dynamic_options/format/date_time/properties/pattern/example2.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Properties
+          module Pattern
+            class Example2 < ApplicationService::Base
+              input :started_at, type: String
+
+              # rubocop:disable Layout/LineLength
+              internal :started_at,
+                       type: String,
+                       check_format: {
+                         is: :datetime,
+                         pattern: /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/
+                       }
+              # rubocop:enable Layout/LineLength
+
+              output :started_at, type: ::DateTime
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.started_at = inputs.started_at
+              end
+
+              def assign_output
+                outputs.started_at = ::DateTime.parse(internals.started_at)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/date_time/properties/pattern/example3.rb
+++ b/examples/usual/dynamic_options/format/date_time/properties/pattern/example3.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module DateTime
+        module Properties
+          module Pattern
+            class Example3 < ApplicationService::Base
+              input :started_at, type: String
+
+              # rubocop:disable Layout/LineLength
+              output :started_at,
+                     type: String,
+                     format: {
+                       is: :datetime,
+                       pattern: /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/
+                     }
+              # rubocop:enable Layout/LineLength
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.started_at = inputs.started_at
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -13,6 +13,14 @@ module Servactory
               false
             end
           },
+          datetime: {
+            pattern: nil,
+            validator: lambda do |value:|
+              DateTime.parse(value) and return true
+            rescue Date::Error
+              false
+            end
+          },
           time: {
             pattern: nil,
             validator: lambda do |value:|

--- a/spec/examples/usual/dynamic_options/format/date_time/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/basic/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Basic::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 25:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::DateTime::Basic::Example1] " \
+                "Input `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 25:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::DateTime::Basic::Example1] " \
+                "Input `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/basic/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Basic::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 25:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::DateTime::Basic::Example2] " \
+                "Internal attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 25:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::DateTime::Basic::Example2] " \
+                "Internal attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/basic/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Basic::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 25:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::DateTime::Basic::Example3] " \
+                "Output attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 25:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::DateTime::Basic::Example3] " \
+                "Output attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/is/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Is::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::DateTime::Is::Example1] " \
+                "Input `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::DateTime::Is::Example1] " \
+                "Input `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/is/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Is::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::DateTime::Is::Example2] " \
+                "Internal attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::DateTime::Is::Example2] " \
+                "Internal attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/is/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Is::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::DateTime::Is::Example3] " \
+                "Output attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::DateTime::Is::Example3] " \
+                "Output attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/message/lambda/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/message/lambda/example1_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Message::Lambda::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `2023-04-14 26:70` does not match the format of `datetime` in `started_at`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `2023-04-14 26:70` does not match the format of `datetime` in `started_at`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/message/lambda/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/message/lambda/example2_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Message::Lambda::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `2023-04-14 26:70` does not match the format of `datetime` in `started_at`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `2023-04-14 26:70` does not match the format of `datetime` in `started_at`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/message/lambda/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/message/lambda/example3_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Message::Lambda::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `2023-04-14 26:70` does not match the format of `datetime` in `started_at`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `2023-04-14 26:70` does not match the format of `datetime` in `started_at`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/message/static/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/message/static/example1_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Message::Static::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid datetime format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid datetime format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/message/static/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/message/static/example2_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Message::Static::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid datetime format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid datetime format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/message/static/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/message/static/example3_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Message::Static::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid datetime format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14 8:58" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14 8:58")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `date`" do
+          let(:started_at) { "2023-04-14 26:70" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid datetime format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/properties/pattern/example1_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example1 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14T08:58:00+00:00" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `datetime`" do
+          let(:started_at) { "2023-04-14 8:58" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example1] " \
+                "Input `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14T08:58:00+00:00" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `datetime`" do
+          let(:started_at) { "2023-04-14 8:58" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example1] " \
+                "Input `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/properties/pattern/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/properties/pattern/example2_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example2 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14T08:58:00+00:00" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `datetime`" do
+          let(:started_at) { "2023-04-14 8:58" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example2] " \
+                "Internal attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14T08:58:00+00:00" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[started_at],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq(DateTime.parse(started_at))
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `datetime`" do
+          let(:started_at) { "2023-04-14 8:58" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example2] " \
+                "Internal attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/date_time/properties/pattern/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/date_time/properties/pattern/example3_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example3 do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14T08:58:00+00:00" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14T08:58:00+00:00")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `datetime`" do
+          let(:started_at) { "2023-04-14 8:58" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example3] " \
+                "Output attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        started_at: started_at
+      }
+    end
+
+    let(:started_at) { "2023-04-14T08:58:00+00:00" }
+
+    include_examples "check class info",
+                     inputs: %i[started_at],
+                     internals: %i[],
+                     outputs: %i[started_at]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.started_at?).to be(true)
+          expect(result.started_at).to eq("2023-04-14T08:58:00+00:00")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `datetime`" do
+          let(:started_at) { "2023-04-14 8:58" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::DateTime::Properties::Pattern::Example3] " \
+                "Output attribute `started_at` does not match `datetime` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      context "when `data`" do
+        it_behaves_like "input required check", name: :started_at
+
+        it_behaves_like "input type check", name: :started_at, expected_type: String
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
input :started_at, type: String, format: :datetime

input :started_at,
      type: String,
      format: {
        is: :datetime,
        message: lambda do |input:, value:, option_value:, **|
          "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
        end
      }
```