### PR TITLE
Add `uuid` format for dynamic option `format`

### DIFF
--- a/examples/usual/dynamic_options/format/uuid/basic/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/basic/example1.rb
@@ -6,16 +6,16 @@ module Usual
       module Uuid
         module Basic
           class Example1 < ApplicationService::Base
-            input :uuid, type: String, format: :uuid
+            input :service_id, type: String, format: :uuid
 
-            output :uuid, type: String
+            output :service_id, type: String
 
             make :assign_output
 
             private
 
             def assign_output
-              outputs.uuid = inputs.uuid
+              outputs.service_id = inputs.service_id
             end
           end
         end

--- a/examples/usual/dynamic_options/format/uuid/basic/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/basic/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Basic
+          class Example1 < ApplicationService::Base
+            input :uuid, type: String, format: :uuid
+
+            output :uuid, type: String
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.uuid = inputs.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/basic/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/basic/example2.rb
@@ -6,11 +6,11 @@ module Usual
       module Uuid
         module Basic
           class Example2 < ApplicationService::Base
-            input :uuid, type: String
+            input :service_id, type: String
 
-            internal :uuid, type: String, check_format: :uuid
+            internal :service_id, type: String, check_format: :uuid
 
-            output :uuid, type: String
+            output :service_id, type: String
 
             make :assign_internal
 
@@ -19,11 +19,11 @@ module Usual
             private
 
             def assign_internal
-              internals.uuid = inputs.uuid
+              internals.service_id = inputs.service_id
             end
 
             def assign_output
-              outputs.uuid = internals.uuid
+              outputs.service_id = internals.service_id
             end
           end
         end

--- a/examples/usual/dynamic_options/format/uuid/basic/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/basic/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Basic
+          class Example2 < ApplicationService::Base
+            input :uuid, type: String
+
+            internal :uuid, type: String, check_format: :uuid
+
+            output :uuid, type: String
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.uuid = inputs.uuid
+            end
+
+            def assign_output
+              outputs.uuid = internals.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/basic/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/basic/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Basic
+          class Example3 < ApplicationService::Base
+            input :uuid, type: String
+
+            output :uuid, type: String, format: :uuid
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.uuid = inputs.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/basic/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/basic/example3.rb
@@ -6,16 +6,16 @@ module Usual
       module Uuid
         module Basic
           class Example3 < ApplicationService::Base
-            input :uuid, type: String
+            input :service_id, type: String
 
-            output :uuid, type: String, format: :uuid
+            output :service_id, type: String, format: :uuid
 
             make :assign_output
 
             private
 
             def assign_output
-              outputs.uuid = inputs.uuid
+              outputs.service_id = inputs.service_id
             end
           end
         end

--- a/examples/usual/dynamic_options/format/uuid/is/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/is/example1.rb
@@ -6,16 +6,16 @@ module Usual
       module Uuid
         module Is
           class Example1 < ApplicationService::Base
-            input :uuid, type: String, format: { is: :uuid }
+            input :service_id, type: String, format: { is: :uuid }
 
-            output :uuid, type: String
+            output :service_id, type: String
 
             make :assign_output
 
             private
 
             def assign_output
-              outputs.uuid = inputs.uuid
+              outputs.service_id = inputs.service_id
             end
           end
         end

--- a/examples/usual/dynamic_options/format/uuid/is/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/is/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Is
+          class Example1 < ApplicationService::Base
+            input :uuid, type: String, format: { is: :uuid }
+
+            output :uuid, type: String
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.uuid = inputs.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/is/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/is/example2.rb
@@ -6,11 +6,11 @@ module Usual
       module Uuid
         module Is
           class Example2 < ApplicationService::Base
-            input :uuid, type: String
+            input :service_id, type: String
 
-            internal :uuid, type: String, check_format: { is: :uuid }
+            internal :service_id, type: String, check_format: { is: :uuid }
 
-            output :uuid, type: String
+            output :service_id, type: String
 
             make :assign_internal
 
@@ -19,11 +19,11 @@ module Usual
             private
 
             def assign_internal
-              internals.uuid = inputs.uuid
+              internals.service_id = inputs.service_id
             end
 
             def assign_output
-              outputs.uuid = internals.uuid
+              outputs.service_id = internals.service_id
             end
           end
         end

--- a/examples/usual/dynamic_options/format/uuid/is/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/is/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Is
+          class Example2 < ApplicationService::Base
+            input :uuid, type: String
+
+            internal :uuid, type: String, check_format: { is: :uuid }
+
+            output :uuid, type: String
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.uuid = inputs.uuid
+            end
+
+            def assign_output
+              outputs.uuid = internals.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/is/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/is/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Is
+          class Example3 < ApplicationService::Base
+            input :uuid, type: String
+
+            output :uuid, type: String, format: { is: :uuid }
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.uuid = inputs.uuid
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/is/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/is/example3.rb
@@ -6,16 +6,16 @@ module Usual
       module Uuid
         module Is
           class Example3 < ApplicationService::Base
-            input :uuid, type: String
+            input :service_id, type: String
 
-            output :uuid, type: String, format: { is: :uuid }
+            output :service_id, type: String, format: { is: :uuid }
 
             make :assign_output
 
             private
 
             def assign_output
-              outputs.uuid = inputs.uuid
+              outputs.service_id = inputs.service_id
             end
           end
         end

--- a/examples/usual/dynamic_options/format/uuid/message/lambda/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/lambda/example1.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Message
+          module Lambda
+            class Example1 < ApplicationService::Base
+              input :uuid,
+                    type: String,
+                    format: {
+                      is: :uuid,
+                      message: lambda do |input:, value:, option_value:, **|
+                        "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
+                      end
+                    }
+
+              output :uuid, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/message/lambda/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/lambda/example1.rb
@@ -7,7 +7,7 @@ module Usual
         module Message
           module Lambda
             class Example1 < ApplicationService::Base
-              input :uuid,
+              input :service_id,
                     type: String,
                     format: {
                       is: :uuid,
@@ -16,14 +16,14 @@ module Usual
                       end
                     }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_output
 
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/message/lambda/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/lambda/example2.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Message
+          module Lambda
+            class Example2 < ApplicationService::Base
+              input :uuid, type: String
+
+              internal :uuid,
+                       type: String,
+                       check_format: {
+                         is: :uuid,
+                         message: lambda do |internal:, value:, option_value:, **|
+                           "Value `#{value}` does not match the format of `#{option_value}` in `#{internal.name}`"
+                         end
+                       }
+
+              output :uuid, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.uuid = inputs.uuid
+              end
+
+              def assign_output
+                outputs.uuid = internals.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/message/lambda/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/lambda/example2.rb
@@ -7,9 +7,9 @@ module Usual
         module Message
           module Lambda
             class Example2 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              internal :uuid,
+              internal :service_id,
                        type: String,
                        check_format: {
                          is: :uuid,
@@ -18,7 +18,7 @@ module Usual
                          end
                        }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_internal
 
@@ -27,11 +27,11 @@ module Usual
               private
 
               def assign_internal
-                internals.uuid = inputs.uuid
+                internals.service_id = inputs.service_id
               end
 
               def assign_output
-                outputs.uuid = internals.uuid
+                outputs.service_id = internals.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/message/lambda/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/lambda/example3.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Message
+          module Lambda
+            class Example3 < ApplicationService::Base
+              input :uuid, type: String
+
+              output :uuid,
+                     type: String,
+                     format: {
+                       is: :uuid,
+                       message: lambda do |output:, value:, option_value:, **|
+                         "Value `#{value}` does not match the format of `#{option_value}` in `#{output.name}`"
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/message/lambda/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/lambda/example3.rb
@@ -7,9 +7,9 @@ module Usual
         module Message
           module Lambda
             class Example3 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              output :uuid,
+              output :service_id,
                      type: String,
                      format: {
                        is: :uuid,
@@ -23,7 +23,7 @@ module Usual
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/message/static/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/static/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Message
+          module Static
+            class Example1 < ApplicationService::Base
+              input :uuid,
+                    type: String,
+                    format: {
+                      is: :uuid,
+                      message: "Invalid date format"
+                    }
+
+              output :uuid, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/message/static/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/static/example1.rb
@@ -7,21 +7,21 @@ module Usual
         module Message
           module Static
             class Example1 < ApplicationService::Base
-              input :uuid,
+              input :service_id,
                     type: String,
                     format: {
                       is: :uuid,
                       message: "Invalid date format"
                     }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_output
 
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/message/static/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/static/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Message
+          module Static
+            class Example2 < ApplicationService::Base
+              input :uuid, type: String
+
+              internal :uuid,
+                       type: String,
+                       check_format: {
+                         is: :uuid,
+                         message: "Invalid date format"
+                       }
+
+              output :uuid, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.uuid = inputs.uuid
+              end
+
+              def assign_output
+                outputs.uuid = internals.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/message/static/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/static/example2.rb
@@ -7,16 +7,16 @@ module Usual
         module Message
           module Static
             class Example2 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              internal :uuid,
+              internal :service_id,
                        type: String,
                        check_format: {
                          is: :uuid,
                          message: "Invalid date format"
                        }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_internal
 
@@ -25,11 +25,11 @@ module Usual
               private
 
               def assign_internal
-                internals.uuid = inputs.uuid
+                internals.service_id = inputs.service_id
               end
 
               def assign_output
-                outputs.uuid = internals.uuid
+                outputs.service_id = internals.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/message/static/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/static/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Message
+          module Static
+            class Example3 < ApplicationService::Base
+              input :uuid, type: String
+
+              output :uuid,
+                     type: String,
+                     format: {
+                       is: :uuid,
+                       message: "Invalid date format"
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/message/static/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/message/static/example3.rb
@@ -7,9 +7,9 @@ module Usual
         module Message
           module Static
             class Example3 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              output :uuid,
+              output :service_id,
                      type: String,
                      format: {
                        is: :uuid,
@@ -21,7 +21,7 @@ module Usual
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/properties/pattern/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/pattern/example1.rb
@@ -7,21 +7,21 @@ module Usual
         module Properties
           module Pattern
             class Example1 < ApplicationService::Base
-              input :uuid,
+              input :service_id,
                     type: String,
                     format: {
                       is: :uuid,
                       pattern: nil # This will disable the value checking based on the pattern
                     }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_output
 
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/properties/pattern/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/pattern/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Properties
+          module Pattern
+            class Example1 < ApplicationService::Base
+              input :uuid,
+                    type: String,
+                    format: {
+                      is: :uuid,
+                      pattern: nil # This will disable the value checking based on the pattern
+                    }
+
+              output :uuid, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/properties/pattern/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/pattern/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Properties
+          module Pattern
+            class Example2 < ApplicationService::Base
+              input :uuid, type: String
+
+              internal :uuid,
+                       type: String,
+                       check_format: {
+                         is: :uuid,
+                         pattern: nil # This will disable the value checking based on the pattern
+                       }
+
+              output :uuid, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.uuid = inputs.uuid
+              end
+
+              def assign_output
+                outputs.uuid = internals.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/properties/pattern/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/pattern/example2.rb
@@ -7,16 +7,16 @@ module Usual
         module Properties
           module Pattern
             class Example2 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              internal :uuid,
+              internal :service_id,
                        type: String,
                        check_format: {
                          is: :uuid,
                          pattern: nil # This will disable the value checking based on the pattern
                        }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_internal
 
@@ -25,11 +25,11 @@ module Usual
               private
 
               def assign_internal
-                internals.uuid = inputs.uuid
+                internals.service_id = inputs.service_id
               end
 
               def assign_output
-                outputs.uuid = internals.uuid
+                outputs.service_id = internals.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/properties/pattern/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/pattern/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Properties
+          module Pattern
+            class Example3 < ApplicationService::Base
+              input :uuid, type: String
+
+              output :uuid,
+                     type: String,
+                     format: {
+                       is: :uuid,
+                       pattern: nil # This will disable the value checking based on the pattern
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/properties/pattern/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/pattern/example3.rb
@@ -7,9 +7,9 @@ module Usual
         module Properties
           module Pattern
             class Example3 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              output :uuid,
+              output :service_id,
                      type: String,
                      format: {
                        is: :uuid,
@@ -21,7 +21,7 @@ module Usual
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/properties/validator/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/validator/example1.rb
@@ -7,7 +7,7 @@ module Usual
         module Properties
           module Validator
             class Example1 < ApplicationService::Base
-              input :uuid,
+              input :service_id,
                     type: String,
                     format: {
                       is: :uuid,
@@ -17,14 +17,14 @@ module Usual
                       end
                     }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_output
 
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/properties/validator/example1.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/validator/example1.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Properties
+          module Validator
+            class Example1 < ApplicationService::Base
+              input :uuid,
+                    type: String,
+                    format: {
+                      is: :uuid,
+                      pattern: nil, # This will disable the value checking based on the pattern
+                      validator: lambda do |value:|
+                        value.size >= 9
+                      end
+                    }
+
+              output :uuid, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/properties/validator/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/validator/example2.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Properties
+          module Validator
+            class Example2 < ApplicationService::Base
+              input :uuid, type: String
+
+              internal :uuid,
+                       type: String,
+                       check_format: {
+                         is: :uuid,
+                         pattern: nil, # This will disable the value checking based on the pattern
+                         validator: lambda do |value:|
+                           value.size >= 9
+                         end
+                       }
+
+              output :uuid, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.uuid = inputs.uuid
+              end
+
+              def assign_output
+                outputs.uuid = internals.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/properties/validator/example2.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/validator/example2.rb
@@ -7,9 +7,9 @@ module Usual
         module Properties
           module Validator
             class Example2 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              internal :uuid,
+              internal :service_id,
                        type: String,
                        check_format: {
                          is: :uuid,
@@ -19,7 +19,7 @@ module Usual
                          end
                        }
 
-              output :uuid, type: String
+              output :service_id, type: String
 
               make :assign_internal
 
@@ -28,11 +28,11 @@ module Usual
               private
 
               def assign_internal
-                internals.uuid = inputs.uuid
+                internals.service_id = inputs.service_id
               end
 
               def assign_output
-                outputs.uuid = internals.uuid
+                outputs.service_id = internals.service_id
               end
             end
           end

--- a/examples/usual/dynamic_options/format/uuid/properties/validator/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/validator/example3.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Uuid
+        module Properties
+          module Validator
+            class Example3 < ApplicationService::Base
+              input :uuid, type: String
+
+              output :uuid,
+                     type: String,
+                     format: {
+                       is: :uuid,
+                       pattern: nil, # This will disable the value checking based on the pattern
+                       validator: lambda do |value:|
+                         value.size >= 9
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.uuid = inputs.uuid
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/uuid/properties/validator/example3.rb
+++ b/examples/usual/dynamic_options/format/uuid/properties/validator/example3.rb
@@ -7,9 +7,9 @@ module Usual
         module Properties
           module Validator
             class Example3 < ApplicationService::Base
-              input :uuid, type: String
+              input :service_id, type: String
 
-              output :uuid,
+              output :service_id,
                      type: String,
                      format: {
                        is: :uuid,
@@ -24,7 +24,7 @@ module Usual
               private
 
               def assign_output
-                outputs.uuid = inputs.uuid
+                outputs.service_id = inputs.service_id
               end
             end
           end

--- a/lib/servactory/maintenance/attributes/options/registrar.rb
+++ b/lib/servactory/maintenance/attributes/options/registrar.rb
@@ -213,7 +213,7 @@ module Servactory
             )
           end
 
-          def register_prepare_option # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          def register_prepare_option # rubocop:disable Metrics/MethodLength
             collection << Servactory::Maintenance::Attributes::Option.new(
               name: :prepare,
               attribute: @attribute,

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -3,8 +3,12 @@
 module Servactory
   module ToolKit
     module DynamicOptions
-      class Format < Must
+      class Format < Must # rubocop:disable Metrics/ClassLength
         DEFAULT_FORMATS = {
+          uuid: {
+            pattern: /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/,
+            validator: ->(value:) { value.present? }
+          },
           email: {
             pattern: URI::MailTo::EMAIL_REGEXP,
             validator: ->(value:) { value.present? }

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -5,12 +5,16 @@ module Servactory
     module DynamicOptions
       class Format < Must
         DEFAULT_FORMATS = {
-          boolean: {
-            pattern: /^(true|false|0|1)$/i,
-            validator: ->(value:) { %w[true 1].include?(value&.downcase) }
-          },
           email: {
             pattern: URI::MailTo::EMAIL_REGEXP,
+            validator: ->(value:) { value.present? }
+          },
+          password: {
+            # NOTE: Pattern 4 » https://dev.to/rasaf_ibrahim/write-regex-password-validation-like-a-pro-5175
+            #       Password must contain one digit from 1 to 9, one lowercase letter, one
+            #       uppercase letter, and one underscore, and it must be 8-16 characters long.
+            #       Usage of any other special character and usage of space is optional.
+            pattern: /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,16}$/,
             validator: ->(value:) { value.present? }
           },
           date: {
@@ -29,14 +33,6 @@ module Servactory
               false
             end
           },
-          password: {
-            # NOTE: Pattern 4 » https://dev.to/rasaf_ibrahim/write-regex-password-validation-like-a-pro-5175
-            #       Password must contain one digit from 1 to 9, one lowercase letter, one
-            #       uppercase letter, and one underscore, and it must be 8-16 characters long.
-            #       Usage of any other special character and usage of space is optional.
-            pattern: /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,16}$/,
-            validator: ->(value:) { value.present? }
-          },
           time: {
             pattern: nil,
             validator: lambda do |value:|
@@ -44,6 +40,10 @@ module Servactory
             rescue ArgumentError
               false
             end
+          },
+          boolean: {
+            pattern: /^(true|false|0|1)$/i,
+            validator: ->(value:) { %w[true 1].include?(value&.downcase) }
           }
         }.freeze
         private_constant :DEFAULT_FORMATS

--- a/spec/examples/usual/dynamic_options/format/uuid/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/basic/example1_spec.rb
@@ -6,33 +6,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example1, type: :serv
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Basic::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -41,7 +41,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example1, type: :serv
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -50,33 +50,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example1, type: :serv
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Basic::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -85,7 +85,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example1, type: :serv
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/basic/example1_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Basic::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Basic::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/basic/example2_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Basic::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Basic::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/basic/example2_spec.rb
@@ -6,33 +6,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example2, type: :serv
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Basic::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -41,7 +41,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example2, type: :serv
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -50,33 +50,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example2, type: :serv
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Basic::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -85,7 +85,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example2, type: :serv
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/basic/example3_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Basic::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Basic::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/basic/example3_spec.rb
@@ -6,33 +6,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example3, type: :serv
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Basic::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -41,7 +41,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example3, type: :serv
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -50,33 +50,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example3, type: :serv
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Basic::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -85,7 +85,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Basic::Example3, type: :serv
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/is/example1_spec.rb
@@ -6,33 +6,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example1, type: :service
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Is::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -41,7 +41,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example1, type: :service
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -50,33 +50,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example1, type: :service
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Is::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -85,7 +85,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example1, type: :service
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/is/example1_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Is::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Is::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/is/example2_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Is::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Is::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/is/example2_spec.rb
@@ -6,33 +6,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example2, type: :service
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Is::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -41,7 +41,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example2, type: :service
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -50,33 +50,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example2, type: :service
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Is::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -85,7 +85,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example2, type: :service
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/is/example3_spec.rb
@@ -6,33 +6,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example3, type: :service
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Is::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -41,7 +41,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example3, type: :service
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -50,33 +50,33 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example3, type: :service
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Is::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -85,7 +85,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example3, type: :service
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/is/example3_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Is::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Is::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Is::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example1_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example1_spec.rb
@@ -6,32 +6,32 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example1, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
-                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+                "Value `my-best-uuid` does not match the format of `uuid` in `service_id`"
               )
             )
           end
@@ -40,7 +40,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example1, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -49,32 +49,32 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example1, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
-                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+                "Value `my-best-uuid` does not match the format of `uuid` in `service_id`"
               )
             )
           end
@@ -83,7 +83,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example1, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example2_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example2_spec.rb
@@ -6,32 +6,32 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example2, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
-                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+                "Value `my-best-uuid` does not match the format of `uuid` in `service_id`"
               )
             )
           end
@@ -40,7 +40,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example2, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -49,32 +49,32 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example2, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
-                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+                "Value `my-best-uuid` does not match the format of `uuid` in `service_id`"
               )
             )
           end
@@ -83,7 +83,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example2, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example3_spec.rb
@@ -6,32 +6,32 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example3, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
-                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+                "Value `my-best-uuid` does not match the format of `uuid` in `service_id`"
               )
             )
           end
@@ -40,7 +40,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example3, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -49,32 +49,32 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example3, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
-                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+                "Value `my-best-uuid` does not match the format of `uuid` in `service_id`"
               )
             )
           end
@@ -83,7 +83,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example3, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/lambda/example3_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Lambda::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `my-best-uuid` does not match the format of `uuid` in `uuid`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/static/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/static/example1_spec.rb
@@ -6,26 +6,26 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example1, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
@@ -40,7 +40,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example1, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -49,26 +49,26 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example1, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
@@ -83,7 +83,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example1, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/static/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/static/example1_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/static/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/static/example2_spec.rb
@@ -6,26 +6,26 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example2, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
@@ -40,7 +40,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example2, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -49,26 +49,26 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example2, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
@@ -83,7 +83,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example2, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/static/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/static/example2_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/static/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/static/example3_spec.rb
@@ -6,26 +6,26 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example3, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
@@ -40,7 +40,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example3, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -49,26 +49,26 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example3, t
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+    let(:service_id) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
-        it { expect(perform).to have_output(:uuid?).with(true) }
-        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+        it { expect(perform).to have_output(:service_id?).with(true) }
+        it { expect(perform).to have_output(:service_id).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "my-best-uuid" }
+          let(:service_id) { "my-best-uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
@@ -83,7 +83,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example3, t
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/message/static/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/message/static/example3_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Message::Static::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "018f0e5d-a7bd-7764-8b88-cdf2b2d22543" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:uuid?).with(true) }
+        it { expect(perform).to have_output(:uuid).with("018f0e5d-a7bd-7764-8b88-cdf2b2d22543") }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "my-best-uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid date format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example1_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { " " }
+          let(:service_id) { " " }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -45,7 +45,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -54,37 +54,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { " " }
+          let(:service_id) { " " }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -93,7 +93,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example1_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example2_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example2_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { " " }
+          let(:service_id) { " " }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -45,7 +45,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -54,37 +54,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { " " }
+          let(:service_id) { " " }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -93,7 +93,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example3_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { " " }
+          let(:service_id) { " " }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -45,7 +45,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -54,37 +54,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { " " }
+          let(:service_id) { " " }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -93,7 +93,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/pattern/example3_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { " " }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Pattern::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example1_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "uuid" }
+          let(:service_id) { "uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -45,7 +45,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -54,37 +54,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "uuid" }
+          let(:service_id) { "uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example1] " \
-                "Input `uuid` does not match `uuid` format"
+                "Input `service_id` does not match `uuid` format"
               )
             )
           end
@@ -93,7 +93,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example1_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example1] " \
+                "Input `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example2_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "uuid" }
+          let(:service_id) { "uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -45,7 +45,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -54,37 +54,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
-                     internals: %i[uuid],
-                     outputs: %i[uuid]
+                     inputs: %i[service_id],
+                     internals: %i[service_id],
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "uuid" }
+          let(:service_id) { "uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Internal,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example2] " \
-                "Internal attribute `uuid` does not match `uuid` format"
+                "Internal attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -93,7 +93,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example2_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[uuid],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example2] " \
+                "Internal attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example3_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        uuid: uuid
+      }
+    end
+
+    let(:uuid) { "my-best-uuid" }
+
+    include_examples "check class info",
+                     inputs: %i[uuid],
+                     internals: %i[],
+                     outputs: %i[uuid]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.uuid?).to be(true)
+          expect(result.uuid).to eq("my-best-uuid")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `uuid`" do
+          let(:uuid) { "uuid" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example3] " \
+                "Output attribute `uuid` does not match `uuid` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/uuid/properties/validator/example3_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "uuid" }
+          let(:service_id) { "uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -45,7 +45,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 
@@ -54,37 +54,37 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
 
     let(:attributes) do
       {
-        uuid: uuid
+        service_id: service_id
       }
     end
 
-    let(:uuid) { "my-best-uuid" }
+    let(:service_id) { "my-best-uuid" }
 
     include_examples "check class info",
-                     inputs: %i[uuid],
+                     inputs: %i[service_id],
                      internals: %i[],
-                     outputs: %i[uuid]
+                     outputs: %i[service_id]
 
     context "when the input arguments are valid" do
       describe "and the data required for work is also valid" do
         it "returns the expected value", :aggregate_failures do
           result = perform
 
-          expect(result.uuid?).to be(true)
-          expect(result.uuid).to eq("my-best-uuid")
+          expect(result.service_id?).to be(true)
+          expect(result.service_id).to eq("my-best-uuid")
         end
       end
 
       describe "but the data required for work is invalid" do
         describe "because the format is not suitable for `uuid`" do
-          let(:uuid) { "uuid" }
+          let(:service_id) { "uuid" }
 
           it "returns expected error" do
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Output,
                 "[Usual::DynamicOptions::Format::Uuid::Properties::Validator::Example3] " \
-                "Output attribute `uuid` does not match `uuid` format"
+                "Output attribute `service_id` does not match `uuid` format"
               )
             )
           end
@@ -93,7 +93,7 @@ RSpec.describe Usual::DynamicOptions::Format::Uuid::Properties::Validator::Examp
     end
 
     context "when the input arguments are invalid" do
-      it { expect { perform }.to have_input(:uuid).valid_with(attributes).type(String).required }
+      it { expect { perform }.to have_input(:service_id).valid_with(attributes).type(String).required }
     end
   end
 end


### PR DESCRIPTION
```ruby
input :service_id, type: String, format: :uuid

input :service_id,
      type: String,
      format: {
        is: :uuid,
        message: lambda do |input:, value:, option_value:, **|
          "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
        end
      }
```