### PR TITLE
Add `duration` format for dynamic option `format`

### DIFF
--- a/examples/usual/dynamic_options/format/duration/basic/example1.rb
+++ b/examples/usual/dynamic_options/format/duration/basic/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Basic
+          class Example1 < ApplicationService::Base
+            input :song_duration, type: String, format: :duration
+
+            output :song_duration, type: ActiveSupport::Duration
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.song_duration = ActiveSupport::Duration.parse(inputs.song_duration)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/basic/example2.rb
+++ b/examples/usual/dynamic_options/format/duration/basic/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Basic
+          class Example2 < ApplicationService::Base
+            input :song_duration, type: String
+
+            internal :song_duration, type: String, check_format: :duration
+
+            output :song_duration, type: ActiveSupport::Duration
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.song_duration = inputs.song_duration
+            end
+
+            def assign_output
+              outputs.song_duration = ActiveSupport::Duration.parse(internals.song_duration)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/basic/example3.rb
+++ b/examples/usual/dynamic_options/format/duration/basic/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Basic
+          class Example3 < ApplicationService::Base
+            input :song_duration, type: String
+
+            output :song_duration, type: String, format: :duration
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.song_duration = inputs.song_duration
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/is/example1.rb
+++ b/examples/usual/dynamic_options/format/duration/is/example1.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Is
+          class Example1 < ApplicationService::Base
+            input :song_duration, type: String, format: { is: :duration }
+
+            output :song_duration, type: ActiveSupport::Duration
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.song_duration = ActiveSupport::Duration.parse(inputs.song_duration)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/is/example2.rb
+++ b/examples/usual/dynamic_options/format/duration/is/example2.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Is
+          class Example2 < ApplicationService::Base
+            input :song_duration, type: String
+
+            internal :song_duration, type: String, check_format: { is: :duration }
+
+            output :song_duration, type: ActiveSupport::Duration
+
+            make :assign_internal
+
+            make :assign_output
+
+            private
+
+            def assign_internal
+              internals.song_duration = inputs.song_duration
+            end
+
+            def assign_output
+              outputs.song_duration = ActiveSupport::Duration.parse(internals.song_duration)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/is/example3.rb
+++ b/examples/usual/dynamic_options/format/duration/is/example3.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Is
+          class Example3 < ApplicationService::Base
+            input :song_duration, type: String
+
+            output :song_duration, type: String, format: { is: :duration }
+
+            make :assign_output
+
+            private
+
+            def assign_output
+              outputs.song_duration = inputs.song_duration
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/message/lambda/example1.rb
+++ b/examples/usual/dynamic_options/format/duration/message/lambda/example1.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Message
+          module Lambda
+            class Example1 < ApplicationService::Base
+              input :song_duration,
+                    type: String,
+                    format: {
+                      is: :duration,
+                      message: lambda do |input:, value:, option_value:, **|
+                        "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
+                      end
+                    }
+
+              output :song_duration, type: ActiveSupport::Duration
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = ActiveSupport::Duration.parse(inputs.song_duration)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/message/lambda/example2.rb
+++ b/examples/usual/dynamic_options/format/duration/message/lambda/example2.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Message
+          module Lambda
+            class Example2 < ApplicationService::Base
+              input :song_duration, type: String
+
+              internal :song_duration,
+                       type: String,
+                       check_format: {
+                         is: :duration,
+                         message: lambda do |internal:, value:, option_value:, **|
+                           "Value `#{value}` does not match the format of `#{option_value}` in `#{internal.name}`"
+                         end
+                       }
+
+              output :song_duration, type: ActiveSupport::Duration
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.song_duration = inputs.song_duration
+              end
+
+              def assign_output
+                outputs.song_duration = ActiveSupport::Duration.parse(internals.song_duration)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/message/lambda/example3.rb
+++ b/examples/usual/dynamic_options/format/duration/message/lambda/example3.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Message
+          module Lambda
+            class Example3 < ApplicationService::Base
+              input :song_duration, type: String
+
+              output :song_duration,
+                     type: String,
+                     format: {
+                       is: :duration,
+                       message: lambda do |output:, value:, option_value:, **|
+                         "Value `#{value}` does not match the format of `#{option_value}` in `#{output.name}`"
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = inputs.song_duration
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/message/static/example1.rb
+++ b/examples/usual/dynamic_options/format/duration/message/static/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Message
+          module Static
+            class Example1 < ApplicationService::Base
+              input :song_duration,
+                    type: String,
+                    format: {
+                      is: :duration,
+                      message: "Invalid duration format"
+                    }
+
+              output :song_duration, type: ActiveSupport::Duration
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = ActiveSupport::Duration.parse(inputs.song_duration)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/message/static/example2.rb
+++ b/examples/usual/dynamic_options/format/duration/message/static/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Message
+          module Static
+            class Example2 < ApplicationService::Base
+              input :song_duration, type: String
+
+              internal :song_duration,
+                       type: String,
+                       check_format: {
+                         is: :duration,
+                         message: "Invalid duration format"
+                       }
+
+              output :song_duration, type: ActiveSupport::Duration
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.song_duration = inputs.song_duration
+              end
+
+              def assign_output
+                outputs.song_duration = ActiveSupport::Duration.parse(internals.song_duration)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/message/static/example3.rb
+++ b/examples/usual/dynamic_options/format/duration/message/static/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Message
+          module Static
+            class Example3 < ApplicationService::Base
+              input :song_duration, type: String
+
+              output :song_duration,
+                     type: String,
+                     format: {
+                       is: :duration,
+                       message: "Invalid duration format"
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = inputs.song_duration
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/properties/pattern/example1.rb
+++ b/examples/usual/dynamic_options/format/duration/properties/pattern/example1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Properties
+          module Pattern
+            class Example1 < ApplicationService::Base
+              input :song_duration,
+                    type: String,
+                    format: {
+                      is: :duration,
+                      pattern: /^P(?=\d+[YMWD])(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$/
+                    }
+
+              output :song_duration, type: ActiveSupport::Duration
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = ActiveSupport::Duration.parse(inputs.song_duration)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/properties/pattern/example2.rb
+++ b/examples/usual/dynamic_options/format/duration/properties/pattern/example2.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Properties
+          module Pattern
+            class Example2 < ApplicationService::Base
+              input :song_duration, type: String
+
+              internal :song_duration,
+                       type: String,
+                       check_format: {
+                         is: :duration,
+                         pattern: /^P(?=\d+[YMWD])(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$/
+                       }
+
+              output :song_duration, type: ActiveSupport::Duration
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.song_duration = inputs.song_duration
+              end
+
+              def assign_output
+                outputs.song_duration = ActiveSupport::Duration.parse(internals.song_duration)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/properties/pattern/example3.rb
+++ b/examples/usual/dynamic_options/format/duration/properties/pattern/example3.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Properties
+          module Pattern
+            class Example3 < ApplicationService::Base
+              input :song_duration, type: String
+
+              output :song_duration,
+                     type: String,
+                     format: {
+                       is: :duration,
+                       pattern: /^P(?=\d+[YMWD])(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$/
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = inputs.song_duration
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/properties/validator/example1.rb
+++ b/examples/usual/dynamic_options/format/duration/properties/validator/example1.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Properties
+          module Validator
+            class Example1 < ApplicationService::Base
+              input :song_duration,
+                    type: String,
+                    format: {
+                      is: :duration,
+                      pattern: nil, # This will disable the value checking based on the pattern
+                      validator: lambda do |value:|
+                        value.start_with?("P") && value.end_with?("D")
+                      end
+                    }
+
+              output :song_duration, type: String
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = inputs.song_duration
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/properties/validator/example2.rb
+++ b/examples/usual/dynamic_options/format/duration/properties/validator/example2.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Properties
+          module Validator
+            class Example2 < ApplicationService::Base
+              input :song_duration, type: String
+
+              internal :song_duration,
+                       type: String,
+                       check_format: {
+                         is: :duration,
+                         pattern: nil, # This will disable the value checking based on the pattern
+                         validator: lambda do |value:|
+                           value.start_with?("P") && value.end_with?("D")
+                         end
+                       }
+
+              output :song_duration, type: String
+
+              make :assign_internal
+
+              make :assign_output
+
+              private
+
+              def assign_internal
+                internals.song_duration = inputs.song_duration
+              end
+
+              def assign_output
+                outputs.song_duration = internals.song_duration
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/format/duration/properties/validator/example3.rb
+++ b/examples/usual/dynamic_options/format/duration/properties/validator/example3.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module Format
+      module Duration
+        module Properties
+          module Validator
+            class Example3 < ApplicationService::Base
+              input :song_duration, type: String
+
+              output :song_duration,
+                     type: String,
+                     format: {
+                       is: :duration,
+                       pattern: nil, # This will disable the value checking based on the pattern
+                       validator: lambda do |value:|
+                         value.start_with?("P") && value.end_with?("D")
+                       end
+                     }
+
+              make :assign_output
+
+              private
+
+              def assign_output
+                outputs.song_duration = inputs.song_duration
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -21,6 +21,14 @@ module Servactory
             pattern: /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,16}$/,
             validator: ->(value:) { value.present? }
           },
+          duration: {
+            pattern: nil,
+            validator: lambda do |value:|
+              ActiveSupport::Duration.parse(value) and return true
+            rescue ActiveSupport::Duration::ISO8601Parser::ParsingError
+              false
+            end
+          },
           date: {
             pattern: nil,
             validator: lambda do |value:|

--- a/spec/examples/usual/dynamic_options/format/duration/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/basic/example1_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Basic::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example1] Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example1] Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/basic/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/basic/example1_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Usual::DynamicOptions::Format::Duration::Basic::Example1, type: :
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
-                "[Usual::DynamicOptions::Format::Duration::Basic::Example1] Input `song_duration` does not match `duration` format"
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example1] Input `song_duration` does not " \
+                "match `duration` format"
               )
             )
           end
@@ -74,7 +75,8 @@ RSpec.describe Usual::DynamicOptions::Format::Duration::Basic::Example1, type: :
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
-                "[Usual::DynamicOptions::Format::Duration::Basic::Example1] Input `song_duration` does not match `duration` format"
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example1] Input `song_duration` does not " \
+                "match `duration` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/duration/basic/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/basic/example2_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Basic::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example2] Internal attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example2] Internal attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/basic/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/basic/example3_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Basic::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example3] Output attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Basic::Example3] Output attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/is/example1_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Usual::DynamicOptions::Format::Duration::Is::Example1, type: :ser
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
-                "[Usual::DynamicOptions::Format::Duration::Is::Example1] Input `song_duration` does not match `duration` format"
+                "[Usual::DynamicOptions::Format::Duration::Is::Example1] Input `song_duration` does not " \
+                "match `duration` format"
               )
             )
           end
@@ -74,7 +75,8 @@ RSpec.describe Usual::DynamicOptions::Format::Duration::Is::Example1, type: :ser
             expect { perform }.to(
               raise_error(
                 ApplicationService::Exceptions::Input,
-                "[Usual::DynamicOptions::Format::Duration::Is::Example1] Input `song_duration` does not match `duration` format"
+                "[Usual::DynamicOptions::Format::Duration::Is::Example1] Input `song_duration` does not " \
+                "match `duration` format"
               )
             )
           end

--- a/spec/examples/usual/dynamic_options/format/duration/is/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/is/example1_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Is::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Is::Example1] Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Is::Example1] Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/is/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/is/example2_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Is::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Is::Example2] Internal attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Is::Example2] Internal attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/is/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/is/example3_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Is::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Is::Example3] Output attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Is::Example3] Output attribute `song_duration` " \
+                "does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/message/lambda/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/message/lambda/example1_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Message::Lambda::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `7D` does not match the format of `duration` in `song_duration`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Value `7D` does not match the format of `duration` in `song_duration`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/message/lambda/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/message/lambda/example2_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Message::Lambda::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `7D` does not match the format of `duration` in `song_duration`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Value `7D` does not match the format of `duration` in `song_duration`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/message/lambda/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/message/lambda/example3_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Message::Lambda::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `7D` does not match the format of `duration` in `song_duration`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Value `7D` does not match the format of `duration` in `song_duration`"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/message/static/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/message/static/example1_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Message::Static::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid duration format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "Invalid duration format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/message/static/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/message/static/example2_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Message::Static::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid duration format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "Invalid duration format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/message/static/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/message/static/example3_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Message::Static::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid duration format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "Invalid duration format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/properties/pattern/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/properties/pattern/example1_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example1] " \
+                "Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example1] " \
+                "Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/properties/pattern/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/properties/pattern/example2_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example2] " \
+                "Internal attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it { expect(perform).to have_output(:song_duration?).with(true) }
+        it { expect(perform).to have_output(:song_duration).with(ActiveSupport::Duration.parse(song_duration)) }
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example2] " \
+                "Internal attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/properties/pattern/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/properties/pattern/example3_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example3] " \
+                "Output attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Pattern::Example3] " \
+                "Output attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/properties/validator/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/properties/validator/example1_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Properties::Validator::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Validator::Example1] " \
+                "Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Input,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Validator::Example1] " \
+                "Input `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/properties/validator/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/properties/validator/example2_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Properties::Validator::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Validator::Example2] " \
+                "Internal attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[song_duration],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Internal,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Validator::Example2] " \
+                "Internal attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/format/duration/properties/validator/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/format/duration/properties/validator/example3_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::Format::Duration::Properties::Validator::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Validator::Example3] " \
+                "Output attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        song_duration: song_duration
+      }
+    end
+
+    let(:song_duration) { "P7D" }
+
+    include_examples "check class info",
+                     inputs: %i[song_duration],
+                     internals: %i[],
+                     outputs: %i[song_duration]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        it "returns the expected value", :aggregate_failures do
+          result = perform
+
+          expect(result.song_duration?).to be(true)
+          expect(result.song_duration).to eq("P7D")
+        end
+      end
+
+      describe "but the data required for work is invalid" do
+        describe "because the format is not suitable for `duration`" do
+          let(:song_duration) { "7D" }
+
+          it "returns expected error" do
+            expect { perform }.to(
+              raise_error(
+                ApplicationService::Exceptions::Output,
+                "[Usual::DynamicOptions::Format::Duration::Properties::Validator::Example3] " \
+                "Output attribute `song_duration` does not match `duration` format"
+              )
+            )
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it { expect { perform }.to have_input(:song_duration).valid_with(attributes).type(String).required }
+    end
+  end
+end


### PR DESCRIPTION
```ruby
input :song_duration, type: String, format: :duration

input :song_duration,
      type: String,
      format: {
        is: :duration,
        message: lambda do |input:, value:, option_value:, **|
          "Value `#{value}` does not match the format of `#{option_value}` in `#{input.name}`"
        end
      }
```