### PR TITLE
Add dynamic option `multiple_of`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,9 +31,9 @@ en:
             max:
               default: "[%{service_class_name}] Input `%{input_name}` received value `%{value}`, which is greater than `%{option_value}`"
             multiple_of:
-              default: "[%{service_class_name}] Input `%{input_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
-              blank: "[%{service_class_name}] Input `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Input `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              default: "[%{service_class_name}] Input `%{input_name}` has the value `%{value}`, which is not a multiple of `%{option_value}`"
+              blank: "[%{service_class_name}] Input `%{input_name}` has an invalid value `%{option_value}` in option `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Input `%{input_name}` has an invalid value `%{option_value}` in option `multiple_of`"
         required:
           default_error:
             default: "[%{service_class_name}] Required input `%{input_name}` is missing"
@@ -71,9 +71,9 @@ en:
             max:
               default: "[%{service_class_name}] Internal attribute `%{internal_name}` received value `%{value}`, which is greater than `%{option_value}`"
             multiple_of:
-              default: "[%{service_class_name}] Internal attribute `%{internal_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
-              blank: "[%{service_class_name}] Internal attribute `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Internal attribute `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              default: "[%{service_class_name}] Internal attribute `%{internal_name}` has the value `%{value}`, which is not a multiple of `%{option_value}`"
+              blank: "[%{service_class_name}] Internal attribute `%{internal_name}` has an invalid value `%{option_value}` in option `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Internal attribute `%{internal_name}` has an invalid value `%{option_value}` in option `multiple_of`"
         type:
           default_error:
             default: "[%{service_class_name}] Wrong type of internal attribute `%{internal_name}`, expected `%{expected_type}`, got `%{given_type}`"
@@ -103,9 +103,9 @@ en:
             max:
               default: "[%{service_class_name}] Output attribute `%{output_name}` received value `%{value}`, which is greater than `%{option_value}`"
             multiple_of:
-              default: "[%{service_class_name}] Output attribute `%{output_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
-              blank: "[%{service_class_name}] Output attribute `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Output attribute `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              default: "[%{service_class_name}] Output attribute `%{output_name}` has the value `%{value}`, which is not a multiple of `%{option_value}`"
+              blank: "[%{service_class_name}] Output attribute `%{output_name}` has an invalid value `%{option_value}` in option `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Output attribute `%{output_name}` has an invalid value `%{option_value}` in option `multiple_of`"
         type:
           default_error:
             default: "[%{service_class_name}] Wrong type of output attribute `%{output_name}`, expected `%{expected_type}`, got `%{given_type}`"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@ en:
               default: "[%{service_class_name}] Input `%{input_name}` received value `%{value}`, which is greater than `%{option_value}`"
             multiple_of:
               default: "[%{service_class_name}] Input `%{input_name}` has the value `%{value}`, which is not a multiple of `%{option_value}`"
-              blank: "[%{service_class_name}] Input `%{input_name}` has an invalid value `%{option_value}` in option `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Input `%{input_name}` has an invalid value `%{option_value}` in option `multiple_of`"
+              blank: "[%{service_class_name}] Input `%{input_name}` has an invalid value `%{option_value}` in option `%{option_name}`"
+              divided_by_0: "[%{service_class_name}] Input `%{input_name}` has an invalid value `%{option_value}` in option `%{option_name}`"
         required:
           default_error:
             default: "[%{service_class_name}] Required input `%{input_name}` is missing"
@@ -72,8 +72,8 @@ en:
               default: "[%{service_class_name}] Internal attribute `%{internal_name}` received value `%{value}`, which is greater than `%{option_value}`"
             multiple_of:
               default: "[%{service_class_name}] Internal attribute `%{internal_name}` has the value `%{value}`, which is not a multiple of `%{option_value}`"
-              blank: "[%{service_class_name}] Internal attribute `%{internal_name}` has an invalid value `%{option_value}` in option `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Internal attribute `%{internal_name}` has an invalid value `%{option_value}` in option `multiple_of`"
+              blank: "[%{service_class_name}] Internal attribute `%{internal_name}` has an invalid value `%{option_value}` in option `%{option_name}`"
+              divided_by_0: "[%{service_class_name}] Internal attribute `%{internal_name}` has an invalid value `%{option_value}` in option `%{option_name}`"
         type:
           default_error:
             default: "[%{service_class_name}] Wrong type of internal attribute `%{internal_name}`, expected `%{expected_type}`, got `%{given_type}`"
@@ -104,8 +104,8 @@ en:
               default: "[%{service_class_name}] Output attribute `%{output_name}` received value `%{value}`, which is greater than `%{option_value}`"
             multiple_of:
               default: "[%{service_class_name}] Output attribute `%{output_name}` has the value `%{value}`, which is not a multiple of `%{option_value}`"
-              blank: "[%{service_class_name}] Output attribute `%{output_name}` has an invalid value `%{option_value}` in option `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Output attribute `%{output_name}` has an invalid value `%{option_value}` in option `multiple_of`"
+              blank: "[%{service_class_name}] Output attribute `%{output_name}` has an invalid value `%{option_value}` in option `%{option_name}`"
+              divided_by_0: "[%{service_class_name}] Output attribute `%{output_name}` has an invalid value `%{option_value}` in option `%{option_name}`"
         type:
           default_error:
             default: "[%{service_class_name}] Wrong type of output attribute `%{output_name}`, expected `%{expected_type}`, got `%{given_type}`"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,10 @@ en:
               default: "[%{service_class_name}] Input `%{input_name}` received value `%{value}`, which is less than `%{option_value}`"
             max:
               default: "[%{service_class_name}] Input `%{input_name}` received value `%{value}`, which is greater than `%{option_value}`"
+            multiple_of:
+              default: "[%{service_class_name}] Input `%{input_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
+              blank: "[%{service_class_name}] Input `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Input `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
         required:
           default_error:
             default: "[%{service_class_name}] Required input `%{input_name}` is missing"
@@ -66,6 +70,10 @@ en:
               default: "[%{service_class_name}] Internal attribute `%{internal_name}` received value `%{value}`, which is less than `%{option_value}`"
             max:
               default: "[%{service_class_name}] Internal attribute `%{internal_name}` received value `%{value}`, which is greater than `%{option_value}`"
+            multiple_of:
+              default: "[%{service_class_name}] Internal attribute `%{internal_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
+              blank: "[%{service_class_name}] Internal attribute `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Internal attribute `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
         type:
           default_error:
             default: "[%{service_class_name}] Wrong type of internal attribute `%{internal_name}`, expected `%{expected_type}`, got `%{given_type}`"
@@ -94,6 +102,10 @@ en:
               default: "[%{service_class_name}] Output attribute `%{output_name}` received value `%{value}`, which is less than `%{option_value}`"
             max:
               default: "[%{service_class_name}] Output attribute `%{output_name}` received value `%{value}`, which is greater than `%{option_value}`"
+            multiple_of:
+              default: "[%{service_class_name}] Output attribute `%{output_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
+              blank: "[%{service_class_name}] Output attribute `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Output attribute `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
         type:
           default_error:
             default: "[%{service_class_name}] Wrong type of output attribute `%{output_name}`, expected `%{expected_type}`, got `%{given_type}`"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -32,8 +32,8 @@ ru:
               default: "[%{service_class_name}] Инпут `%{input_name}` получил значение `%{value}`, которое больше `%{option_value}`"
             multiple_of:
               default: "[%{service_class_name}] Инпут `%{input_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
-              blank: "[%{service_class_name}] Инпут `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Инпут `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              blank: "[%{service_class_name}] Инпут `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `%{option_name}`"
+              divided_by_0: "[%{service_class_name}] Инпут `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `%{option_name}`"
         required:
           default_error:
             default: "[%{service_class_name}] Обязательный инпут `%{input_name}` отсутствует"
@@ -72,8 +72,8 @@ ru:
               default: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` получил значение `%{value}`, которое больше `%{option_value}`"
             multiple_of:
               default: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
-              blank: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              blank: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `%{option_name}`"
+              divided_by_0: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `%{option_name}`"
         type:
           default_error:
             default: "[%{service_class_name}] Неправильный тип внутреннего атрибута `%{internal_name}`, ожидалось `%{expected_type}`, получено `%{given_type}`"
@@ -104,8 +104,8 @@ ru:
               default: "[%{service_class_name}] Выходящий атрибут `%{output_name}` получил значение `%{value}`, которое больше `%{option_value}`"
             multiple_of:
               default: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
-              blank: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
-              divided_by_0: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              blank: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `%{option_name}`"
+              divided_by_0: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `%{option_name}`"
         type:
           default_error:
             default: "[%{service_class_name}] Неправильный тип выходящего атрибута `%{output_name}`, ожидалось `%{expected_type}`, получено `%{given_type}`"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -30,6 +30,10 @@ ru:
               default: "[%{service_class_name}] Инпут `%{input_name}` получил значение `%{value}`, которое меньше `%{option_value}`"
             max:
               default: "[%{service_class_name}] Инпут `%{input_name}` получил значение `%{value}`, которое больше `%{option_value}`"
+            multiple_of:
+              default: "[%{service_class_name}] Инпут `%{input_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
+              blank: "[%{service_class_name}] Инпут `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Инпут `%{input_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
         required:
           default_error:
             default: "[%{service_class_name}] Обязательный инпут `%{input_name}` отсутствует"
@@ -66,6 +70,10 @@ ru:
               default: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` получил значение `%{value}`, которое меньше `%{option_value}`"
             max:
               default: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` получил значение `%{value}`, которое больше `%{option_value}`"
+            multiple_of:
+              default: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
+              blank: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Внутренний атрибут `%{internal_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
         type:
           default_error:
             default: "[%{service_class_name}] Неправильный тип внутреннего атрибута `%{internal_name}`, ожидалось `%{expected_type}`, получено `%{given_type}`"
@@ -94,6 +102,10 @@ ru:
               default: "[%{service_class_name}] Выходящий атрибут `%{output_name}` получил значение `%{value}`, которое меньше `%{option_value}`"
             max:
               default: "[%{service_class_name}] Выходящий атрибут `%{output_name}` получил значение `%{value}`, которое больше `%{option_value}`"
+            multiple_of:
+              default: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет значение `%{value}`, которое не кратно `%{option_value}`"
+              blank: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
+              divided_by_0: "[%{service_class_name}] Выходящий атрибут `%{output_name}` имеет недопустимое значение `%{option_value}` в опции `multiple_of`"
         type:
           default_error:
             default: "[%{service_class_name}] Неправильный тип выходящего атрибута `%{output_name}`, ожидалось `%{expected_type}`, получено `%{given_type}`"

--- a/examples/application_service/base.rb
+++ b/examples/application_service/base.rb
@@ -50,6 +50,7 @@ module ApplicationService
           Servactory::ToolKit::DynamicOptions::Format.use,
           Servactory::ToolKit::DynamicOptions::Min.use,
           Servactory::ToolKit::DynamicOptions::Max.use,
+          Servactory::ToolKit::DynamicOptions::MultipleOf.use,
           ApplicationService::DynamicOptions::CustomEq.use
         ]
       )
@@ -78,6 +79,7 @@ module ApplicationService
           Servactory::ToolKit::DynamicOptions::Format.use(:check_format),
           Servactory::ToolKit::DynamicOptions::Min.use(:minimum), # Examples of
           Servactory::ToolKit::DynamicOptions::Max.use(:maximum), # custom names
+          Servactory::ToolKit::DynamicOptions::MultipleOf.use,
           ApplicationService::DynamicOptions::CustomEq.use(:best_custom_eq)
         ]
       )
@@ -113,6 +115,7 @@ module ApplicationService
           ),
           Servactory::ToolKit::DynamicOptions::Min.use,
           Servactory::ToolKit::DynamicOptions::Max.use,
+          Servactory::ToolKit::DynamicOptions::MultipleOf.use,
           ApplicationService::DynamicOptions::CustomEq.use
         ]
       )

--- a/examples/application_service/base.rb
+++ b/examples/application_service/base.rb
@@ -79,7 +79,7 @@ module ApplicationService
           Servactory::ToolKit::DynamicOptions::Format.use(:check_format),
           Servactory::ToolKit::DynamicOptions::Min.use(:minimum), # Examples of
           Servactory::ToolKit::DynamicOptions::Max.use(:maximum), # custom names
-          Servactory::ToolKit::DynamicOptions::MultipleOf.use,
+          Servactory::ToolKit::DynamicOptions::MultipleOf.use(:divisible_by),
           ApplicationService::DynamicOptions::CustomEq.use(:best_custom_eq)
         ]
       )

--- a/examples/usual/dynamic_options/multiple_of/example1.rb
+++ b/examples/usual/dynamic_options/multiple_of/example1.rb
@@ -6,7 +6,7 @@ module Usual
       class Example1 < ApplicationService::Base
         input :number, type: [Integer, Float, Rational, BigDecimal], multiple_of: 9
 
-        internal :number, type: [Integer, Float, Rational, BigDecimal], multiple_of: 6
+        internal :number, type: [Integer, Float, Rational, BigDecimal], divisible_by: 6
 
         output :number, type: [Integer, Float, Rational, BigDecimal], multiple_of: 5
 

--- a/examples/usual/dynamic_options/multiple_of/example1.rb
+++ b/examples/usual/dynamic_options/multiple_of/example1.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module MultipleOf
+      class Example1 < ApplicationService::Base
+        input :number, type: [Integer, Float, Rational, BigDecimal], multiple_of: 9
+
+        internal :number, type: [Integer, Float, Rational, BigDecimal], multiple_of: 6
+
+        output :number, type: [Integer, Float, Rational, BigDecimal], multiple_of: 5
+
+        make :assign_internal_number
+
+        make :assign_output_number
+
+        private
+
+        def assign_internal_number
+          internals.number = inputs.number
+        end
+
+        def assign_output_number
+          outputs.number = internals.number
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/multiple_of/example2.rb
+++ b/examples/usual/dynamic_options/multiple_of/example2.rb
@@ -16,7 +16,7 @@ module Usual
 
         internal :number,
                  type: [Integer, Float, Rational, BigDecimal],
-                 multiple_of: {
+                 divisible_by: {
                    is: 6,
                    message: lambda do |internal:, value:, option_value:, **|
                      "Internal `#{internal.name}` has the value `#{value}`, " \

--- a/examples/usual/dynamic_options/multiple_of/example2.rb
+++ b/examples/usual/dynamic_options/multiple_of/example2.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module MultipleOf
+      class Example2 < ApplicationService::Base
+        input :number,
+              type: [Integer, Float, Rational, BigDecimal],
+              multiple_of: {
+                is: 9,
+                message: lambda do |input:, value:, option_value:, **|
+                  "Input `#{input.name}` has the value `#{value}`, " \
+                    "which is not a multiple of `#{option_value}`"
+                end
+              }
+
+        internal :number,
+                 type: [Integer, Float, Rational, BigDecimal],
+                 multiple_of: {
+                   is: 6,
+                   message: lambda do |internal:, value:, option_value:, **|
+                     "Internal `#{internal.name}` has the value `#{value}`, " \
+                       "which is not a multiple of `#{option_value}`"
+                   end
+                 }
+
+        output :number,
+               type: [Integer, Float, Rational, BigDecimal],
+               multiple_of: {
+                 is: 5,
+                 message: lambda do |output:, value:, option_value:, **|
+                   "Output `#{output.name}` has the value `#{value}`, " \
+                     "which is not a multiple of `#{option_value}`"
+                 end
+               }
+
+        make :assign_internal_number
+
+        make :assign_output_number
+
+        private
+
+        def assign_internal_number
+          internals.number = inputs.number
+        end
+
+        def assign_output_number
+          outputs.number = internals.number
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/multiple_of/example3.rb
+++ b/examples/usual/dynamic_options/multiple_of/example3.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Usual
+  module DynamicOptions
+    module MultipleOf
+      class Example3 < ApplicationService::Base
+        input :number,
+              type: [Integer, Float, Rational, BigDecimal],
+              multiple_of: {
+                is: 9,
+                message: "The input is an incorrect multiple"
+              }
+
+        internal :number,
+                 type: [Integer, Float, Rational, BigDecimal],
+                 multiple_of: {
+                   is: 6,
+                   message: "The internal is an incorrect multiple"
+                 }
+
+        output :number,
+               type: [Integer, Float, Rational, BigDecimal],
+               multiple_of: {
+                 is: 5,
+                 message: "The output is an incorrect multiple"
+               }
+
+        make :assign_internal_number
+
+        make :assign_output_number
+
+        private
+
+        def assign_internal_number
+          internals.number = inputs.number
+        end
+
+        def assign_output_number
+          outputs.number = internals.number
+        end
+      end
+    end
+  end
+end

--- a/examples/usual/dynamic_options/multiple_of/example3.rb
+++ b/examples/usual/dynamic_options/multiple_of/example3.rb
@@ -13,7 +13,7 @@ module Usual
 
         internal :number,
                  type: [Integer, Float, Rational, BigDecimal],
-                 multiple_of: {
+                 divisible_by: {
                    is: 6,
                    message: "The internal is an incorrect multiple"
                  }

--- a/examples/wrong/dynamic_options/multiple_of/example1.rb
+++ b/examples/wrong/dynamic_options/multiple_of/example1.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Wrong
+  module DynamicOptions
+    module MultipleOf
+      class Example1 < ApplicationService::Base
+        input :number, type: Integer, multiple_of: nil
+
+        make :smth
+
+        private
+
+        def smth
+          # ...
+        end
+      end
+    end
+  end
+end

--- a/examples/wrong/dynamic_options/multiple_of/example2.rb
+++ b/examples/wrong/dynamic_options/multiple_of/example2.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Wrong
+  module DynamicOptions
+    module MultipleOf
+      class Example2 < ApplicationService::Base
+        input :number, type: Integer, multiple_of: 0
+
+        make :smth
+
+        private
+
+        def smth
+          # ...
+        end
+      end
+    end
+  end
+end

--- a/examples/wrong/dynamic_options/multiple_of/example3.rb
+++ b/examples/wrong/dynamic_options/multiple_of/example3.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Wrong
+  module DynamicOptions
+    module MultipleOf
+      class Example3 < ApplicationService::Base
+        internal :number, type: Integer, divisible_by: nil
+
+        make :assign_internal
+
+        private
+
+        def assign_internal
+          internals.number = 10
+        end
+      end
+    end
+  end
+end

--- a/examples/wrong/dynamic_options/multiple_of/example4.rb
+++ b/examples/wrong/dynamic_options/multiple_of/example4.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Wrong
+  module DynamicOptions
+    module MultipleOf
+      class Example4 < ApplicationService::Base
+        internal :number, type: Integer, divisible_by: 0
+
+        make :assign_internal
+
+        private
+
+        def assign_internal
+          internals.number = 10
+        end
+      end
+    end
+  end
+end

--- a/examples/wrong/dynamic_options/multiple_of/example5.rb
+++ b/examples/wrong/dynamic_options/multiple_of/example5.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Wrong
+  module DynamicOptions
+    module MultipleOf
+      class Example5 < ApplicationService::Base
+        output :number, type: Integer, multiple_of: nil
+
+        make :assign_output
+
+        private
+
+        def assign_output
+          outputs.number = 10
+        end
+      end
+    end
+  end
+end

--- a/examples/wrong/dynamic_options/multiple_of/example6.rb
+++ b/examples/wrong/dynamic_options/multiple_of/example6.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Wrong
+  module DynamicOptions
+    module MultipleOf
+      class Example6 < ApplicationService::Base
+        output :number, type: Integer, multiple_of: 0
+
+        make :assign_output
+
+        private
+
+        def assign_output
+          outputs.number = 10
+        end
+      end
+    end
+  end
+end

--- a/lib/servactory/tool_kit/dynamic_options/consists_of.rb
+++ b/lib/servactory/tool_kit/dynamic_options/consists_of.rb
@@ -63,7 +63,7 @@ module Servactory
 
         ########################################################################
 
-        def message_for_input_with(service:, input:, value:, option_value:, reason:, **)
+        def message_for_input_with(service:, input:, value:, option_name:, option_value:, reason:, **)
           i18n_key = "inputs.validations.must.dynamic_options.consists_of"
           i18n_key += reason.present? ? ".#{reason}" : ".default"
 
@@ -71,12 +71,13 @@ module Servactory
             i18n_key,
             service_class_name: service.class_name,
             input_name: input.name,
+            option_name:,
             expected_type: Array(option_value).uniq.join(", "),
             given_type: given_type_for(values: value, option_value:)
           )
         end
 
-        def message_for_internal_with(service:, internal:, value:, option_value:, reason:, **)
+        def message_for_internal_with(service:, internal:, value:, option_name:, option_value:, reason:, **)
           i18n_key = "internals.validations.must.dynamic_options.consists_of"
           i18n_key += reason.present? ? ".#{reason}" : ".default"
 
@@ -84,12 +85,13 @@ module Servactory
             i18n_key,
             service_class_name: service.class_name,
             internal_name: internal.name,
+            option_name:,
             expected_type: Array(option_value).uniq.join(", "),
             given_type: given_type_for(values: value, option_value:)
           )
         end
 
-        def message_for_output_with(service:, output:, value:, option_value:, reason:, **)
+        def message_for_output_with(service:, output:, value:, option_name:, option_value:, reason:, **)
           i18n_key = "outputs.validations.must.dynamic_options.consists_of"
           i18n_key += reason.present? ? ".#{reason}" : ".default"
 
@@ -97,6 +99,7 @@ module Servactory
             i18n_key,
             service_class_name: service.class_name,
             output_name: output.name,
+            option_name:,
             expected_type: Array(option_value).uniq.join(", "),
             given_type: given_type_for(values: value, option_value:)
           )

--- a/lib/servactory/tool_kit/dynamic_options/format.rb
+++ b/lib/servactory/tool_kit/dynamic_options/format.rb
@@ -113,7 +113,7 @@ module Servactory
 
         ########################################################################
 
-        def message_for_input_with(service:, input:, value:, option_value:, reason:, **)
+        def message_for_input_with(service:, input:, value:, option_name:, option_value:, reason:, **)
           i18n_key = "inputs.validations.must.dynamic_options.format"
           i18n_key += reason.present? ? ".#{reason}" : ".default"
 
@@ -121,11 +121,12 @@ module Servactory
             i18n_key,
             input_name: input.name,
             value:,
+            option_name:,
             format_name: option_value.present? ? option_value : option_value.inspect
           )
         end
 
-        def message_for_internal_with(service:, internal:, value:, option_value:, reason:, **)
+        def message_for_internal_with(service:, internal:, value:, option_name:, option_value:, reason:, **)
           i18n_key = "internals.validations.must.dynamic_options.format"
           i18n_key += reason.present? ? ".#{reason}" : ".default"
 
@@ -133,11 +134,12 @@ module Servactory
             i18n_key,
             internal_name: internal.name,
             value:,
+            option_name:,
             format_name: option_value.present? ? option_value : option_value.inspect
           )
         end
 
-        def message_for_output_with(service:, output:, value:, option_value:, reason:, **)
+        def message_for_output_with(service:, output:, value:, option_name:, option_value:, reason:, **)
           i18n_key = "outputs.validations.must.dynamic_options.format"
           i18n_key += reason.present? ? ".#{reason}" : ".default"
 
@@ -145,6 +147,7 @@ module Servactory
             i18n_key,
             output_name: output.name,
             value:,
+            option_name:,
             format_name: option_value.present? ? option_value : option_value.inspect
           )
         end

--- a/lib/servactory/tool_kit/dynamic_options/max.rb
+++ b/lib/servactory/tool_kit/dynamic_options/max.rb
@@ -33,29 +33,32 @@ module Servactory
 
         ########################################################################
 
-        def message_for_input_with(service:, input:, value:, option_value:, **)
+        def message_for_input_with(service:, input:, value:, option_name:, option_value:, **)
           service.translate(
             "inputs.validations.must.dynamic_options.max.default",
             input_name: input.name,
             value:,
+            option_name:,
             option_value:
           )
         end
 
-        def message_for_internal_with(service:, internal:, value:, option_value:, **)
+        def message_for_internal_with(service:, internal:, value:, option_name:, option_value:, **)
           service.translate(
             "internals.validations.must.dynamic_options.max.default",
             internal_name: internal.name,
             value:,
+            option_name:,
             option_value:
           )
         end
 
-        def message_for_output_with(service:, output:, value:, option_value:, **)
+        def message_for_output_with(service:, output:, value:, option_name:, option_value:, **)
           service.translate(
             "outputs.validations.must.dynamic_options.max.default",
             output_name: output.name,
             value:,
+            option_name:,
             option_value:
           )
         end

--- a/lib/servactory/tool_kit/dynamic_options/min.rb
+++ b/lib/servactory/tool_kit/dynamic_options/min.rb
@@ -33,29 +33,32 @@ module Servactory
 
         ########################################################################
 
-        def message_for_input_with(service:, input:, value:, option_value:, **)
+        def message_for_input_with(service:, input:, value:, option_name:, option_value:, **)
           service.translate(
             "inputs.validations.must.dynamic_options.min.default",
             input_name: input.name,
             value:,
+            option_name:,
             option_value:
           )
         end
 
-        def message_for_internal_with(service:, internal:, value:, option_value:, **)
+        def message_for_internal_with(service:, internal:, value:, option_name:, option_value:, **)
           service.translate(
             "internals.validations.must.dynamic_options.min.default",
             internal_name: internal.name,
             value:,
+            option_name:,
             option_value:
           )
         end
 
-        def message_for_output_with(service:, output:, value:, option_value:, **)
+        def message_for_output_with(service:, output:, value:, option_name:, option_value:, **)
           service.translate(
             "outputs.validations.must.dynamic_options.min.default",
             output_name: output.name,
             value:,
+            option_name:,
             option_value:
           )
         end

--- a/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
+++ b/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
@@ -24,8 +24,8 @@ module Servactory
           case value
           when Integer, Float, Rational, BigDecimal
             return false if option.value.blank?
-            return false unless [Numeric, Float, Rational, BigDecimal].any? { |c| option.value.is_a?(c) }
             return false if option.value.zero?
+            return false unless [Numeric, Float, Rational, BigDecimal].any? { |c| option.value.is_a?(c) }
 
             (value % option.value).zero?
           else

--- a/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
+++ b/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Servactory
+  module ToolKit
+    module DynamicOptions
+      class MultipleOf < Must
+        def self.use(option_name = :multiple_of)
+          new(option_name).must(:be_multiple_of)
+        end
+
+        def condition_for_input_with(...)
+          common_condition_with(...)
+        end
+
+        def condition_for_internal_with(...)
+          common_condition_with(...)
+        end
+
+        def condition_for_output_with(...)
+          common_condition_with(...)
+        end
+
+        def common_condition_with(value:, option:, **)
+          case value
+          when Integer, Float, Rational, BigDecimal
+            return false if option.value.blank?
+            return false unless [Numeric, Float, Rational, BigDecimal].any? { |c| option.value.is_a?(c) }
+            return false if option.value.zero?
+
+            (value % option.value).zero?
+          else
+            false
+          end
+        end
+
+        ########################################################################
+
+        def message_for_input_with(service:, input:, value:, option_value:, **) # rubocop:disable Metrics/MethodLength
+          i18n_key = "inputs.validations.must.dynamic_options.multiple_of"
+
+          i18n_key += if option_value.blank?
+                        ".blank"
+                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| value.is_a?(c) } && value.zero?
+                        ".divided_by_0"
+                      else
+                        ".default"
+                      end
+
+          service.translate(
+            i18n_key,
+            input_name: input.name,
+            value:,
+            option_value: option_value.inspect
+          )
+        end
+
+        def message_for_internal_with(service:, internal:, value:, option_value:, **) # rubocop:disable Metrics/MethodLength
+          i18n_key = "internals.validations.must.dynamic_options.multiple_of"
+
+          i18n_key += if option_value.blank?
+                        ".blank"
+                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| value.is_a?(c) } && value.zero?
+                        ".divided_by_0"
+                      else
+                        ".default"
+                      end
+
+          service.translate(
+            i18n_key,
+            internal_name: internal.name,
+            value:,
+            option_value: option_value.inspect
+          )
+        end
+
+        def message_for_output_with(service:, output:, value:, option_value:, **) # rubocop:disable Metrics/MethodLength
+          i18n_key = "outputs.validations.must.dynamic_options.multiple_of"
+
+          i18n_key += if option_value.blank?
+                        ".blank"
+                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| value.is_a?(c) } && value.zero?
+                        ".divided_by_0"
+                      else
+                        ".default"
+                      end
+
+          service.translate(
+            i18n_key,
+            output_name: output.name,
+            value:,
+            option_value: option_value.inspect
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
+++ b/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
@@ -35,7 +35,7 @@ module Servactory
 
         ########################################################################
 
-        def message_for_input_with(service:, input:, value:, option_value:, **) # rubocop:disable Metrics/MethodLength
+        def message_for_input_with(service:, input:, value:, option_name:, option_value:, **) # rubocop:disable Metrics/MethodLength
           i18n_key = "inputs.validations.must.dynamic_options.multiple_of"
 
           i18n_key += if option_value.blank?
@@ -50,11 +50,12 @@ module Servactory
             i18n_key,
             input_name: input.name,
             value:,
+            option_name:,
             option_value: option_value.inspect
           )
         end
 
-        def message_for_internal_with(service:, internal:, value:, option_value:, **) # rubocop:disable Metrics/MethodLength
+        def message_for_internal_with(service:, internal:, value:, option_name:, option_value:, **) # rubocop:disable Metrics/MethodLength
           i18n_key = "internals.validations.must.dynamic_options.multiple_of"
 
           i18n_key += if option_value.blank?
@@ -69,11 +70,12 @@ module Servactory
             i18n_key,
             internal_name: internal.name,
             value:,
+            option_name:,
             option_value: option_value.inspect
           )
         end
 
-        def message_for_output_with(service:, output:, value:, option_value:, **) # rubocop:disable Metrics/MethodLength
+        def message_for_output_with(service:, output:, value:, option_name:, option_value:, **) # rubocop:disable Metrics/MethodLength
           i18n_key = "outputs.validations.must.dynamic_options.multiple_of"
 
           i18n_key += if option_value.blank?
@@ -88,6 +90,7 @@ module Servactory
             i18n_key,
             output_name: output.name,
             value:,
+            option_name:,
             option_value: option_value.inspect
           )
         end

--- a/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
+++ b/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
@@ -40,7 +40,8 @@ module Servactory
 
           i18n_key += if option_value.blank?
                         ".blank"
-                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| value.is_a?(c) } && value.zero?
+                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| option_value.is_a?(c) } &&
+                            option_value.zero?
                         ".divided_by_0"
                       else
                         ".default"
@@ -60,7 +61,8 @@ module Servactory
 
           i18n_key += if option_value.blank?
                         ".blank"
-                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| value.is_a?(c) } && value.zero?
+                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| option_value.is_a?(c) } &&
+                            option_value.zero?
                         ".divided_by_0"
                       else
                         ".default"
@@ -80,7 +82,8 @@ module Servactory
 
           i18n_key += if option_value.blank?
                         ".blank"
-                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| value.is_a?(c) } && value.zero?
+                      elsif [Numeric, Float, Rational, BigDecimal].any? { |c| option_value.is_a?(c) } &&
+                            option_value.zero?
                         ".divided_by_0"
                       else
                         ".default"

--- a/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
+++ b/lib/servactory/tool_kit/dynamic_options/multiple_of.rb
@@ -24,8 +24,8 @@ module Servactory
           case value
           when Integer, Float, Rational, BigDecimal
             return false if option.value.blank?
-            return false if option.value.zero?
             return false unless [Numeric, Float, Rational, BigDecimal].any? { |c| option.value.is_a?(c) }
+            return false if option.value.zero?
 
             (value % option.value).zero?
           else

--- a/lib/servactory/tool_kit/dynamic_options/must.rb
+++ b/lib/servactory/tool_kit/dynamic_options/must.rb
@@ -5,11 +5,14 @@ module Servactory
     module DynamicOptions
       class Must
         class WorkOption
-          attr_reader :value,
+          attr_reader :name,
+                      :value,
                       :message,
                       :properties
 
-          def initialize(data, body_key:, body_fallback:)
+          def initialize(name, data, body_key:, body_fallback:)
+            @name = name
+
             @value =
               if data.is_a?(Hash) && data.key?(body_key)
                 data.delete(body_key)
@@ -37,7 +40,7 @@ module Servactory
 
         def equivalent_with(name)
           lambda do |data|
-            option = WorkOption.new(data, body_key: @body_key, body_fallback: @body_fallback)
+            option = WorkOption.new(@option_name, data, body_key: @body_key, body_fallback: @body_fallback)
 
             {
               must: {
@@ -74,7 +77,7 @@ module Servactory
           is_option_message_proc = option.message.is_a?(Proc) if is_option_message_present
 
           lambda do |input: nil, internal: nil, output: nil, **attributes|
-            default_attributes = { **attributes, option_value: option.value }
+            default_attributes = { **attributes, option_name: option.name, option_value: option.value }
 
             if Servactory::Utils.really_input?(input)
               if is_option_message_present

--- a/sig/lib/servactory/tool_kit/dynamic_options/must.rbs
+++ b/sig/lib/servactory/tool_kit/dynamic_options/must.rbs
@@ -3,6 +3,7 @@ module Servactory
     module DynamicOptions
       class Must
         class WorkOption
+          attr_reader name: Symbol
           attr_reader value: untyped
           attr_reader message: (Proc | String | nil)
           attr_reader properties: Hash[Symbol, untyped]

--- a/spec/examples/usual/dynamic_options/multiple_of/example1_spec.rb
+++ b/spec/examples/usual/dynamic_options/multiple_of/example1_spec.rb
@@ -1,0 +1,501 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::MultipleOf::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 90 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[number],
+                     outputs: [:number]
+
+    context "when the input arguments are valid" do
+      describe "and the number required for work is also valid" do
+        context "when `number` is `Integer`" do
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90) }
+        end
+
+        context "when `number` is `Float`" do
+          let(:number) { 90.0 }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90.0) }
+        end
+
+        context "when `number` is `Rational`" do
+          let(:number) { Rational(90) }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with((90 / 1)) }
+        end
+
+        context "when `number` is `BigDecimal`" do
+          let(:number) { BigDecimal("90") }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(0.90e2) } # rubocop:disable Style/ExponentialNotation
+        end
+      end
+
+      describe "but the number required for work is invalid" do
+        context "when `number` is `Integer`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Float`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Rational`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { Rational(12) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12/1`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { Rational(9) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9/1`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { Rational(18) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18/1`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `BigDecimal`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { BigDecimal("12") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { BigDecimal("9") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { BigDecimal("18") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it do
+        expect { perform }.to(
+          have_input(:number).valid_with(attributes).types(Integer, Float, Rational, BigDecimal).required
+        )
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 90 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[number],
+                     outputs: [:number]
+
+    context "when the input arguments are valid" do
+      describe "and the number required for work is also valid" do
+        context "when `number` is `Integer`" do
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90) }
+        end
+
+        context "when `number` is `Float`" do
+          let(:number) { 90.0 }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90.0) }
+        end
+
+        context "when `number` is `Rational`" do
+          let(:number) { Rational(90) }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with((90 / 1)) }
+        end
+
+        context "when `number` is `BigDecimal`" do
+          let(:number) { BigDecimal("90") }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(0.90e2) } # rubocop:disable Style/ExponentialNotation
+        end
+      end
+
+      describe "but the number required for work is invalid" do
+        context "when `number` is `Integer`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Float`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Rational`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { Rational(12) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12/1`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { Rational(9) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9/1`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { Rational(18) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18/1`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `BigDecimal`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { BigDecimal("12") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { BigDecimal("9") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Internal attribute `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { BigDecimal("18") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "[Usual::DynamicOptions::MultipleOf::Example1] " \
+                    "Output attribute `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it do
+        expect { perform }.to(
+          have_input(:number).valid_with(attributes).types(Integer, Float, Rational, BigDecimal).required
+        )
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/multiple_of/example2_spec.rb
+++ b/spec/examples/usual/dynamic_options/multiple_of/example2_spec.rb
@@ -1,0 +1,477 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::MultipleOf::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 90 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[number],
+                     outputs: [:number]
+
+    context "when the input arguments are valid" do
+      describe "and the number required for work is also valid" do
+        context "when `number` is `Integer`" do
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90) }
+        end
+
+        context "when `number` is `Float`" do
+          let(:number) { 90.0 }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90.0) }
+        end
+
+        context "when `number` is `Rational`" do
+          let(:number) { Rational(90) }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with((90 / 1)) }
+        end
+
+        context "when `number` is `BigDecimal`" do
+          let(:number) { BigDecimal("90") }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(0.90e2) } # rubocop:disable Style/ExponentialNotation
+        end
+      end
+
+      describe "but the number required for work is invalid" do
+        context "when `number` is `Integer`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Float`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Rational`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { Rational(12) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12/1`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { Rational(9) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9/1`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { Rational(18) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18/1`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `BigDecimal`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { BigDecimal("12") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { BigDecimal("9") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { BigDecimal("18") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it do
+        expect { perform }.to(
+          have_input(:number).valid_with(attributes).types(Integer, Float, Rational, BigDecimal).required
+        )
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 90 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[number],
+                     outputs: [:number]
+
+    context "when the input arguments are valid" do
+      describe "and the number required for work is also valid" do
+        context "when `number` is `Integer`" do
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90) }
+        end
+
+        context "when `number` is `Float`" do
+          let(:number) { 90.0 }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90.0) }
+        end
+
+        context "when `number` is `Rational`" do
+          let(:number) { Rational(90) }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with((90 / 1)) }
+        end
+
+        context "when `number` is `BigDecimal`" do
+          let(:number) { BigDecimal("90") }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(0.90e2) } # rubocop:disable Style/ExponentialNotation
+        end
+      end
+
+      describe "but the number required for work is invalid" do
+        context "when `number` is `Integer`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Float`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Rational`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { Rational(12) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12/1`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { Rational(9) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9/1`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { Rational(18) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18/1`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `BigDecimal`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { BigDecimal("12") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "Input `number` has the value `12.0`, which is not a multiple of `9`"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { BigDecimal("9") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "Internal `number` has the value `9.0`, which is not a multiple of `6`"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { BigDecimal("18") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "Output `number` has the value `18.0`, which is not a multiple of `5`"
+                  )
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it do
+        expect { perform }.to(
+          have_input(:number).valid_with(attributes).types(Integer, Float, Rational, BigDecimal).required
+        )
+      end
+    end
+  end
+end

--- a/spec/examples/usual/dynamic_options/multiple_of/example3_spec.rb
+++ b/spec/examples/usual/dynamic_options/multiple_of/example3_spec.rb
@@ -1,0 +1,477 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::DynamicOptions::MultipleOf::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 90 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[number],
+                     outputs: [:number]
+
+    context "when the input arguments are valid" do
+      describe "and the number required for work is also valid" do
+        context "when `number` is `Integer`" do
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90) }
+        end
+
+        context "when `number` is `Float`" do
+          let(:number) { 90.0 }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90.0) }
+        end
+
+        context "when `number` is `Rational`" do
+          let(:number) { Rational(90) }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with((90 / 1)) }
+        end
+
+        context "when `number` is `BigDecimal`" do
+          let(:number) { BigDecimal("90") }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(0.90e2) } # rubocop:disable Style/ExponentialNotation
+        end
+      end
+
+      describe "but the number required for work is invalid" do
+        context "when `number` is `Integer`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Float`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Rational`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { Rational(12) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { Rational(9) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { Rational(18) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `BigDecimal`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { BigDecimal("12") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { BigDecimal("9") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { BigDecimal("18") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it do
+        expect { perform }.to(
+          have_input(:number).valid_with(attributes).types(Integer, Float, Rational, BigDecimal).required
+        )
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 90 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[number],
+                     outputs: [:number]
+
+    context "when the input arguments are valid" do
+      describe "and the number required for work is also valid" do
+        context "when `number` is `Integer`" do
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90) }
+        end
+
+        context "when `number` is `Float`" do
+          let(:number) { 90.0 }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(90.0) }
+        end
+
+        context "when `number` is `Rational`" do
+          let(:number) { Rational(90) }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with((90 / 1)) }
+        end
+
+        context "when `number` is `BigDecimal`" do
+          let(:number) { BigDecimal("90") }
+
+          include_examples "success result class"
+
+          it { expect(perform).to have_output(:number?).with(true) }
+          it { expect(perform).to have_output(:number).with(0.90e2) } # rubocop:disable Style/ExponentialNotation
+        end
+      end
+
+      describe "but the number required for work is invalid" do
+        context "when `number` is `Integer`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Float`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { 12.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { 9.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { 18.0 }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `Rational`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { Rational(12) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { Rational(9) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { Rational(18) }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+
+        context "when `number` is `BigDecimal`" do
+          describe "because the value is greater than specified" do
+            describe "for `input` attribute" do
+              let(:number) { BigDecimal("12") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Input,
+                    "The input is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `internal` attribute" do
+              let(:number) { BigDecimal("9") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Internal,
+                    "The internal is an incorrect multiple"
+                  )
+                )
+              end
+            end
+
+            describe "for `output` attribute" do
+              let(:number) { BigDecimal("18") }
+
+              it "returns expected error" do
+                expect { perform }.to(
+                  raise_error(
+                    ApplicationService::Exceptions::Output,
+                    "The output is an incorrect multiple"
+                  )
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when the input arguments are invalid" do
+      it do
+        expect { perform }.to(
+          have_input(:number).valid_with(attributes).types(Integer, Float, Rational, BigDecimal).required
+        )
+      end
+    end
+  end
+end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example1_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example1_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example1, type: :service do
             raise_error(
               ApplicationService::Exceptions::Input,
               "[Wrong::DynamicOptions::MultipleOf::Example1] " \
-              "Инпут `number` имеет недопустимое значение `nil` в опции `multiple_of`"
+              "Input `number` has an invalid value `nil` in option `multiple_of`"
             )
           )
         end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example1_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example1_spec.rb
@@ -36,4 +36,40 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example1, type: :service do
     #   it { expect { perform }.to have_input(:number).valid_with(attributes).type(Integer).required }
     # end
   end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 10 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Input,
+              "[Wrong::DynamicOptions::MultipleOf::Example1] " \
+              "Input `number` has an invalid value `nil` in option `multiple_of`"
+            )
+          )
+        end
+      end
+    end
+
+    # NOTE: Will not work due to the `nil` value in the option.
+    # context "when the input arguments are invalid" do
+    #   it { expect { perform }.to have_input(:number).valid_with(attributes).type(Integer).required }
+    # end
+  end
 end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example1_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example1_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Wrong::DynamicOptions::MultipleOf::Example1, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 10 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Input,
+              "[Wrong::DynamicOptions::MultipleOf::Example1] " \
+              "Инпут `number` имеет недопустимое значение `nil` в опции `multiple_of`"
+            )
+          )
+        end
+      end
+    end
+
+    # NOTE: Will not work due to the `nil` value in the option.
+    # context "when the input arguments are invalid" do
+    #   it { expect { perform }.to have_input(:number).valid_with(attributes).type(Integer).required }
+    # end
+  end
+end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example2, type: :service do
             raise_error(
               ApplicationService::Exceptions::Input,
               "[Wrong::DynamicOptions::MultipleOf::Example2] " \
-              "Input `number` has the value `10`, which is not a multiple of `0`"
+              "Input `number` has an invalid value `0` in option `multiple_of`"
             )
           )
         end
@@ -60,7 +60,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example2, type: :service do
             raise_error(
               ApplicationService::Exceptions::Input,
               "[Wrong::DynamicOptions::MultipleOf::Example2] " \
-              "Input `number` has the value `10`, which is not a multiple of `0`"
+              "Input `number` has an invalid value `0` in option `multiple_of`"
             )
           )
         end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Wrong::DynamicOptions::MultipleOf::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call!(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 10 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Input,
+              "[Wrong::DynamicOptions::MultipleOf::Example2] " \
+              "Инпут `number` имеет значение `10`, которое не кратно `0`"
+            )
+          )
+        end
+      end
+    end
+
+    # NOTE: Will not work due to division by 0.
+    # context "when the input arguments are invalid" do
+    #   it { expect { perform }.to have_input(:number).valid_with(attributes).type(Integer).required }
+    # end
+  end
+end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example2, type: :service do
             raise_error(
               ApplicationService::Exceptions::Input,
               "[Wrong::DynamicOptions::MultipleOf::Example2] " \
-              "Инпут `number` имеет значение `10`, которое не кратно `0`"
+              "Input `number` has the value `10`, which is not a multiple of `0`"
             )
           )
         end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example2_spec.rb
@@ -36,4 +36,40 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example2, type: :service do
     #   it { expect { perform }.to have_input(:number).valid_with(attributes).type(Integer).required }
     # end
   end
+
+  describe ".call" do
+    subject(:perform) { described_class.call(**attributes) }
+
+    let(:attributes) do
+      {
+        number:
+      }
+    end
+
+    let(:number) { 10 }
+
+    include_examples "check class info",
+                     inputs: %i[number],
+                     internals: %i[],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Input,
+              "[Wrong::DynamicOptions::MultipleOf::Example2] " \
+              "Input `number` has the value `10`, which is not a multiple of `0`"
+            )
+          )
+        end
+      end
+    end
+
+    # NOTE: Will not work due to division by 0.
+    # context "when the input arguments are invalid" do
+    #   it { expect { perform }.to have_input(:number).valid_with(attributes).type(Integer).required }
+    # end
+  end
 end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example3_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example3_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example3, type: :service do
             raise_error(
               ApplicationService::Exceptions::Internal,
               "[Wrong::DynamicOptions::MultipleOf::Example3] " \
-              "Internal attribute `number` has an invalid value `nil` in option `multiple_of`"
+              "Internal attribute `number` has an invalid value `nil` in option `divisible_by`"
             )
           )
         end
@@ -39,7 +39,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example3, type: :service do
             raise_error(
               ApplicationService::Exceptions::Internal,
               "[Wrong::DynamicOptions::MultipleOf::Example3] " \
-              "Internal attribute `number` has an invalid value `nil` in option `multiple_of`"
+              "Internal attribute `number` has an invalid value `nil` in option `divisible_by`"
             )
           )
         end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example3_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example3_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Wrong::DynamicOptions::MultipleOf::Example3, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call! }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[number],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Internal,
+              "[Wrong::DynamicOptions::MultipleOf::Example3] " \
+              "Internal attribute `number` has an invalid value `nil` in option `multiple_of`"
+            )
+          )
+        end
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[number],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Internal,
+              "[Wrong::DynamicOptions::MultipleOf::Example3] " \
+              "Internal attribute `number` has an invalid value `nil` in option `multiple_of`"
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example4_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example4_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example4, type: :service do
             raise_error(
               ApplicationService::Exceptions::Internal,
               "[Wrong::DynamicOptions::MultipleOf::Example4] " \
-              "Internal attribute `number` has the value `10`, which is not a multiple of `0`"
+              "Internal attribute `number` has an invalid value `0` in option `divisible_by`"
             )
           )
         end
@@ -39,7 +39,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example4, type: :service do
             raise_error(
               ApplicationService::Exceptions::Internal,
               "[Wrong::DynamicOptions::MultipleOf::Example4] " \
-              "Internal attribute `number` has the value `10`, which is not a multiple of `0`"
+              "Internal attribute `number` has an invalid value `0` in option `divisible_by`"
             )
           )
         end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example4_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example4_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Wrong::DynamicOptions::MultipleOf::Example4, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call! }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[number],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Internal,
+              "[Wrong::DynamicOptions::MultipleOf::Example4] " \
+              "Internal attribute `number` has the value `10`, which is not a multiple of `0`"
+            )
+          )
+        end
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[number],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Internal,
+              "[Wrong::DynamicOptions::MultipleOf::Example4] " \
+              "Internal attribute `number` has the value `10`, which is not a multiple of `0`"
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example5_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example5_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Wrong::DynamicOptions::MultipleOf::Example5, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call! }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[],
+                     outputs: %i[number]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Output,
+              "[Wrong::DynamicOptions::MultipleOf::Example5] " \
+              "Output attribute `number` has an invalid value `nil` in option `multiple_of`"
+            )
+          )
+        end
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[],
+                     outputs: %i[number]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Output,
+              "[Wrong::DynamicOptions::MultipleOf::Example5] " \
+              "Output attribute `number` has an invalid value `nil` in option `multiple_of`"
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example6_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example6_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example6, type: :service do
             raise_error(
               ApplicationService::Exceptions::Output,
               "[Wrong::DynamicOptions::MultipleOf::Example6] " \
-              "Output attribute `number` has the value `10`, which is not a multiple of `0`"
+              "Output attribute `number` has an invalid value `0` in option `multiple_of`"
             )
           )
         end
@@ -39,7 +39,7 @@ RSpec.describe Wrong::DynamicOptions::MultipleOf::Example6, type: :service do
             raise_error(
               ApplicationService::Exceptions::Output,
               "[Wrong::DynamicOptions::MultipleOf::Example6] " \
-              "Output attribute `number` has the value `10`, which is not a multiple of `0`"
+              "Output attribute `number` has an invalid value `0` in option `multiple_of`"
             )
           )
         end

--- a/spec/examples/wrong/dynamic_options/multiple_of/example6_spec.rb
+++ b/spec/examples/wrong/dynamic_options/multiple_of/example6_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Wrong::DynamicOptions::MultipleOf::Example6, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call! }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[],
+                     outputs: %i[number]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Output,
+              "[Wrong::DynamicOptions::MultipleOf::Example6] " \
+              "Output attribute `number` has the value `10`, which is not a multiple of `0`"
+            )
+          )
+        end
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[],
+                     outputs: %i[number]
+
+    context "when the input arguments are valid" do
+      describe "but the data required for work is invalid" do
+        it "returns expected error" do
+          expect { perform }.to(
+            raise_error(
+              ApplicationService::Exceptions::Output,
+              "[Wrong::DynamicOptions::MultipleOf::Example6] " \
+              "Output attribute `number` has the value `10`, which is not a multiple of `0`"
+            )
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
input :number, type: Integer, multiple_of: 2

input :number,
      type: Integer,
      multiple_of: {
        is: 2,
        message: lambda do |input:, value:, option_value:, **|
          "Value `#{value}` is not multiple of `#{option_value}`"
        end
      }
```