### PR TITLE
[28.08.2024] Update libraries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,31 +9,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.4)
+    activesupport (7.2.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     appraisal (2.5.0)
       bundler
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    async (2.12.1)
-      console (~> 1.25, >= 1.25.2)
+    async (2.16.1)
+      console (~> 1.26)
       fiber-annotation
       io-event (~> 1.6, >= 1.6.5)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     coderay (1.1.3)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
-    console (1.25.2)
+    console (1.27.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
@@ -45,7 +46,7 @@ GEM
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
-    fiber-storage (0.1.2)
+    fiber-storage (1.0.0)
     fileutils (1.7.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -57,25 +58,24 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.0)
     method_source (1.1.0)
-    minitest (5.24.1)
-    mutex_m (0.2.0)
-    parallel (1.25.1)
-    parser (3.3.3.0)
+    minitest (5.25.1)
+    parallel (1.26.3)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.8.0)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.5.1)
+    rbs (3.5.3)
       logger
     regexp_parser (2.9.2)
-    rexml (3.3.1)
+    rexml (3.3.6)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -83,25 +83,25 @@ GEM
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.64.1)
+    rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
+      regexp_parser (>= 2.4, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
@@ -144,7 +144,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     yard (0.9.36)
-    zeitwerk (2.6.16)
+    zeitwerk (2.6.17)
 
 PLATFORMS
   x86_64-darwin-21
@@ -168,4 +168,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.5.14
+   2.5.15

--- a/servactory.gemspec
+++ b/servactory.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0") # rubocop:disable Gemspec/RequiredRubyVersion
 
-  spec.add_runtime_dependency "activesupport", ">= 5.1", "< 8.0"
-  spec.add_runtime_dependency "i18n", "~> 1.14"
-  spec.add_runtime_dependency "zeitwerk", "~> 2.6"
+  spec.add_dependency "activesupport", ">= 5.1", "< 8.0"
+  spec.add_dependency "i18n", "~> 1.14"
+  spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "appraisal", "~> 2.5"
   spec.add_development_dependency "async", ">= 1.31"


### PR DESCRIPTION
- [x] activesupport 7.1.3.4 → 7.2.1 [diff](https://my.diffend.io/gems/activesupport/7.1.3.4/7.2.1) [changelog](https://github.com/rails/rails/blob/v7.2.1/activesupport/CHANGELOG.md)
- [x] async 2.12.1 → 2.16.1 [diff](https://my.diffend.io/gems/async/2.12.1/2.16.1)
- [x] concurrent-ruby 1.3.3 → 1.3.4 [diff](https://my.diffend.io/gems/concurrent-ruby/1.3.3/1.3.4) [changelog](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/CHANGELOG.md)
- [x] console 1.25.2 → 1.27.0 [diff](https://my.diffend.io/gems/console/1.25.2/1.27.0)
- [x] fiber-storage 0.1.2 → 1.0.0 [diff](https://my.diffend.io/gems/fiber-storage/0.1.2/1.0.0)
- [x] minitest 5.24.1 → 5.25.1 [diff](https://my.diffend.io/gems/minitest/5.24.1/5.25.1) [changelog](https://github.com/minitest/minitest/blob/master/History.rdoc)
- [x] parallel 1.25.1 → 1.26.3 [diff](https://my.diffend.io/gems/parallel/1.25.1/1.26.3)
- [x] parser 3.3.3.0 → 3.3.4.2 [diff](https://my.diffend.io/gems/parser/3.3.3.0/3.3.4.2) [changelog](https://github.com/whitequark/parser/blob/v3.3.4.2/CHANGELOG.md)
- [x] racc 1.8.0 → 1.8.1 [diff](https://my.diffend.io/gems/racc/1.8.0/1.8.1) [changelog](https://github.com/ruby/racc/releases)
- [x] rbs 3.5.1 → 3.5.3 [diff](https://my.diffend.io/gems/rbs/3.5.1/3.5.3) [changelog](https://github.com/ruby/rbs/blob/master/CHANGELOG.md)
- [x] rexml 3.3.1 → 3.3.6 [diff](https://my.diffend.io/gems/rexml/3.3.1/3.3.6) [changelog](https://github.com/ruby/rexml/releases/tag/v3.3.6)
- [x] rspec-expectations 3.13.1 → 3.13.2 [diff](https://my.diffend.io/gems/rspec-expectations/3.13.1/3.13.2) [changelog](https://github.com/rspec/rspec-expectations/blob/v3.13.2/Changelog.md#3132--2024-08-20)
- [x] rubocop 1.64.1 → 1.65.1 [diff](https://my.diffend.io/gems/rubocop/1.64.1/1.65.1) [changelog](https://github.com/rubocop/rubocop/releases/tag/v1.65.1)
- [x] rubocop-ast 1.31.3 → 1.32.1 [diff](https://my.diffend.io/gems/rubocop-ast/1.31.3/1.32.1) [changelog](https://github.com/rubocop/rubocop-ast/blob/master/CHANGELOG.md)
- [x] zeitwerk 2.6.16 → 2.6.17 [diff](https://my.diffend.io/gems/zeitwerk/2.6.16/2.6.17) [changelog](https://github.com/fxn/zeitwerk/blob/master/CHANGELOG.md#2617-29-july-2024)