### PR TITLE
Add ability to collect combinations for method names in `action_shortcuts`

### DIFF
--- a/examples/application_service/base.rb
+++ b/examples/application_service/base.rb
@@ -116,37 +116,14 @@ module ApplicationService
       )
 
       action_shortcuts(
-        # EXAMPLE:  assign :payment!
-        # RESULT:   assign_payment!
-        # Eq:
-        # {
-        #   assign: {
-        #     prefix: :assign,
-        #     suffix: nil
-        #   }
-        # }
         %i[assign],
         {
-          # EXAMPLE:  restrict :payment!
-          # RESULT:   create_payment_restriction!
           restrict: {
             prefix: :create,
             suffix: :restriction
           }
         }
       )
-
-      # action_shortcuts [
-      #   :assign,
-      #   {
-      #     # EXAMPLE:  restrict :payment!
-      #     # RESULT:   create_payment_restriction!
-      #     restrict: {
-      #       prefix: :create,
-      #       suffix: :restriction
-      #     }
-      #   }
-      # ]
 
       action_aliases %i[play do_it!]
 

--- a/examples/application_service/base.rb
+++ b/examples/application_service/base.rb
@@ -115,7 +115,39 @@ module ApplicationService
         ]
       )
 
-      action_shortcuts %i[assign]
+      action_shortcuts(
+        # EXAMPLE:  assign :payment!
+        # RESULT:   assign_payment!
+        # Eq:
+        # {
+        #   assign: {
+        #     prefix: :assign,
+        #     suffix: nil
+        #   }
+        # }
+        %i[assign],
+        {
+          # EXAMPLE:  restrict :payment!
+          # RESULT:   create_payment_restriction!
+          restrict: {
+            prefix: :create,
+            suffix: :restriction
+          }
+        }
+      )
+
+      # action_shortcuts [
+      #   :assign,
+      #   {
+      #     # EXAMPLE:  restrict :payment!
+      #     # RESULT:   create_payment_restriction!
+      #     restrict: {
+      #       prefix: :create,
+      #       suffix: :restriction
+      #     }
+      #   }
+      # ]
+
       action_aliases %i[play do_it!]
 
       i18n_root_key :servactory

--- a/examples/usual/action_shortcuts/example2.rb
+++ b/examples/usual/action_shortcuts/example2.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Usual
+  module ActionShortcuts
+    class Example2 < ApplicationService::Base
+      PaymentRestriction = Data.define(:code)
+
+      restrict :payment!
+
+      private
+
+      def create_payment_restriction!
+        PaymentRestriction.create!(
+          reason: "Suspicion of fraud"
+        )
+      end
+    end
+  end
+end

--- a/examples/usual/action_shortcuts/example2.rb
+++ b/examples/usual/action_shortcuts/example2.rb
@@ -3,14 +3,14 @@
 module Usual
   module ActionShortcuts
     class Example2 < ApplicationService::Base
-      PaymentRestriction = Data.define(:code)
+      PaymentRestriction = Data.define(:reason)
 
       restrict :payment!
 
       private
 
       def create_payment_restriction!
-        PaymentRestriction.create!(
+        PaymentRestriction.new(
           reason: "Suspicion of fraud"
         )
       end

--- a/examples/usual/action_shortcuts/example2.rb
+++ b/examples/usual/action_shortcuts/example2.rb
@@ -3,7 +3,7 @@
 module Usual
   module ActionShortcuts
     class Example2 < ApplicationService::Base
-      PaymentRestriction = Data.define(:reason)
+      PaymentRestriction = Struct.new(:reason, keyword_init: true)
 
       restrict :payment!
 

--- a/lib/generators/servactory/templates/services/application_service/base.rb
+++ b/lib/generators/servactory/templates/services/application_service/base.rb
@@ -52,7 +52,15 @@ module ApplicationService
 
       # hash_mode_class_names [CustomHash]
 
-      # action_shortcuts %i[assign build create save]
+      # action_shortcuts(
+      #   %i[assign build create save],
+      #   {
+      #     restrict: {
+      #       prefix: :create,
+      #       suffix: :restriction
+      #     }
+      #   }
+      # )
 
       # action_aliases %i[do_it!]
 

--- a/lib/servactory/actions/dsl.rb
+++ b/lib/servactory/actions/dsl.rb
@@ -106,40 +106,32 @@ module Servactory
         end
 
         def method_missing_for_shortcuts_for_make(_shortcut_name, action_shortcut, *args)
-          # method_options = args.last.is_a?(Hash) ? args.pop : {}
+          method_options = args.last.is_a?(Hash) ? args.pop : {}
 
-          action_name = args.pop.to_s
+          args.each do |method_name|
+            full_method_name = build_method_name_for_shortcuts_for_make_with(
+              method_name.to_s,
+              action_shortcut
+            )
 
-          method_prefix = action_shortcut.fetch(:prefix)
-          method_suffix = action_shortcut.fetch(:suffix)
-
-          method_body, method_body_t =
-            if action_name.end_with?("!", "?")
-              t = action_name.slice!(-1)
-
-              [action_name, t]
-            else
-              [action_name, nil]
-            end
-
-          full_method_name = ""
-
-          full_method_name += "#{method_prefix}_" if method_prefix.present?
-
-          full_method_name += method_body.to_s
-
-          full_method_name += "_#{method_suffix}" if method_suffix.present?
-
-          full_method_name += method_body_t if method_body_t.present?
-
-          puts
-          puts full_method_name.inspect
-          puts
-
-          # TODO: Builder???
-          args.each do |_method_name|
             make(full_method_name, **method_options)
           end
+        end
+
+        def build_method_name_for_shortcuts_for_make_with(method_name, action_shortcut)
+          prefix = action_shortcut.fetch(:prefix)
+          suffix = action_shortcut.fetch(:suffix)
+
+          method_body, special_char =
+            Servactory::Utils.extract_special_character_from(method_name.to_s)
+
+          parts = []
+          parts << "#{prefix}_" if prefix.present?
+          parts << method_body
+          parts << "_#{suffix}" if suffix.present?
+          parts << special_char if special_char
+
+          parts.join.to_sym
         end
 
         def respond_to_missing?(name, *)

--- a/lib/servactory/actions/dsl.rb
+++ b/lib/servactory/actions/dsl.rb
@@ -87,16 +87,16 @@ module Servactory
         end
 
         def method_missing(name, ...)
-          return method_missing_for_action_aliases(name, ...) if config.action_aliases.include?(name)
+          return method_missing_for_action_aliases(...) if config.action_aliases.include?(name)
 
           if (action_shortcut = config.action_shortcuts.find_by(name:)).present?
-            return method_missing_for_shortcuts_for_make(name, action_shortcut, ...)
+            return method_missing_for_shortcuts_for_make(action_shortcut, ...)
           end
 
           super
         end
 
-        def method_missing_for_action_aliases(_alias_name, *args)
+        def method_missing_for_action_aliases(*args)
           method_name = args.first
           method_options = args.last.is_a?(Hash) ? args.pop : {}
 
@@ -105,7 +105,7 @@ module Servactory
           make(method_name, **method_options)
         end
 
-        def method_missing_for_shortcuts_for_make(_shortcut_name, action_shortcut, *args)
+        def method_missing_for_shortcuts_for_make(action_shortcut, *args)
           method_options = args.last.is_a?(Hash) ? args.pop : {}
 
           args.each do |method_name|

--- a/lib/servactory/configuration/actions/shortcuts/collection.rb
+++ b/lib/servactory/configuration/actions/shortcuts/collection.rb
@@ -6,10 +6,20 @@ module Servactory
       module Shortcuts
         class Collection
           extend Forwardable
-          def_delegators :@collection, :<<, :each, :merge, :include?
+          def_delegators :@collection, :merge!, :fetch
 
           def initialize(*)
-            @collection = Set.new
+            @collection = {}
+          end
+
+          alias merge merge!
+
+          def shortcuts
+            flat_map(&:keys)
+          end
+
+          def find_by(name:)
+            fetch(name, nil)
           end
         end
       end

--- a/lib/servactory/configuration/actions/shortcuts/collection.rb
+++ b/lib/servactory/configuration/actions/shortcuts/collection.rb
@@ -6,7 +6,7 @@ module Servactory
       module Shortcuts
         class Collection
           extend Forwardable
-          def_delegators :@collection, :merge!, :fetch
+          def_delegators :@collection, :merge!, :fetch, :keys
 
           def initialize(*)
             @collection = {}
@@ -15,7 +15,7 @@ module Servactory
           alias merge merge!
 
           def shortcuts
-            flat_map(&:keys)
+            keys
           end
 
           def find_by(name:)

--- a/lib/servactory/configuration/factory.rb
+++ b/lib/servactory/configuration/factory.rb
@@ -2,7 +2,7 @@
 
 module Servactory
   module Configuration
-    class Factory
+    class Factory # rubocop:disable Metrics/ClassLength
       def initialize(config)
         @config = config
       end
@@ -63,7 +63,7 @@ module Servactory
         @config.action_aliases.merge(action_aliases)
       end
 
-      def action_shortcuts(array, hash = {})
+      def action_shortcuts(array, hash = {}) # rubocop:disable Metrics/MethodLength
         prepared = array.to_h do |action_shortcut|
           [
             action_shortcut,

--- a/lib/servactory/configuration/factory.rb
+++ b/lib/servactory/configuration/factory.rb
@@ -63,8 +63,20 @@ module Servactory
         @config.action_aliases.merge(action_aliases)
       end
 
-      def action_shortcuts(action_shortcuts)
-        @config.action_shortcuts.merge(action_shortcuts)
+      def action_shortcuts(array, hash = {})
+        prepared = array.to_h do |action_shortcut|
+          [
+            action_shortcut,
+            {
+              prefix: action_shortcut,
+              suffix: nil
+            }
+          ]
+        end
+
+        prepared = prepared.merge(hash)
+
+        @config.action_shortcuts.merge(prepared)
       end
 
       def i18n_root_key(value)

--- a/lib/servactory/utils.rb
+++ b/lib/servactory/utils.rb
@@ -46,6 +46,14 @@ module Servactory
       false
     end
 
+    def extract_special_character_from(string)
+      if string.end_with?("!", "?")
+        [string.chop, string[-1]]
+      else
+        [string, nil]
+      end
+    end
+
     FALSE_VALUES = [
       false,
       nil, "",

--- a/sig/lib/servactory/actions/dsl.rbs
+++ b/sig/lib/servactory/actions/dsl.rbs
@@ -31,6 +31,8 @@ module Servactory
 
         def method_missing_for_shortcuts_for_make: (Symbol name, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
 
+        def build_method_name_for_shortcuts_for_make_with: (Symbol name, Hash[Symbol, untyped] action_shortcut) -> Symbol
+
         def respond_to_missing?: (Symbol name, *untyped) -> bool
 
         def next_position: -> Integer

--- a/sig/lib/servactory/actions/dsl.rbs
+++ b/sig/lib/servactory/actions/dsl.rbs
@@ -27,9 +27,9 @@ module Servactory
 
         def method_missing: (Symbol name, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
 
-        def method_missing_for_action_aliases: (Symbol name, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
+        def method_missing_for_action_aliases: (*untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
 
-        def method_missing_for_shortcuts_for_make: (Symbol name, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
+        def method_missing_for_shortcuts_for_make: (Hash[Symbol, untyped] action_shortcut, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> void
 
         def build_method_name_for_shortcuts_for_make_with: (Symbol name, Hash[Symbol, untyped] action_shortcut) -> Symbol
 

--- a/sig/lib/servactory/configuration/actions/shortcuts/collection.rbs
+++ b/sig/lib/servactory/configuration/actions/shortcuts/collection.rbs
@@ -5,9 +5,15 @@ module Servactory
         class Collection
           extend Forwardable
 
-          @collection: Set[Symbol]
+          @collection: Hash[Symbol, Symbol]
 
           def initialize: (*untyped) -> void
+
+          alias merge merge!
+
+          def shortcuts: () -> Array[Symbol]
+
+          def find_by: (name: Symbol) -> Hash[Symbol, Symbol]
         end
       end
     end

--- a/sig/lib/servactory/utils.rbs
+++ b/sig/lib/servactory/utils.rbs
@@ -14,6 +14,8 @@ module Servactory
 
     def self?.really_output?: ((Inputs::Input | Internals::Internal | Outputs::Output)? attribute) -> bool
 
+    def self?.extract_special_character_from: (String string) -> Array[String | nil]
+
     # @param value [#to_s]
     # @return [Boolean]
     def self?.true?: (untyped value) -> untyped

--- a/spec/examples/usual/action_shortcuts/example2_spec.rb
+++ b/spec/examples/usual/action_shortcuts/example2_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Usual::ActionShortcuts::Example2, type: :service do
+  describe ".call!" do
+    subject(:perform) { described_class.call! }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        # it { expect(perform).to have_output(:number).contains(7) }
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:perform) { described_class.call }
+
+    include_examples "check class info",
+                     inputs: %i[],
+                     internals: %i[],
+                     outputs: %i[]
+
+    context "when the input arguments are valid" do
+      describe "and the data required for work is also valid" do
+        include_examples "success result class"
+
+        # it { expect(perform).to have_output(:number).contains(7) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
action_shortcuts(
  %i[assign],
  {
    restrict: {
      prefix: :create,
      suffix: :restriction
    }
  }
)
```

```ruby
restrict :payment!
```

```ruby
def create_payment_restriction!
  PaymentRestriction.create!(
    reason: "Suspicion of fraud"
  )
end
```