### PR TITLE
Using `fail_*!` methods to raise exceptions

### DIFF
--- a/lib/servactory/context/warehouse/inputs.rb
+++ b/lib/servactory/context/warehouse/inputs.rb
@@ -44,11 +44,7 @@ module Servactory
             input_name:
           )
 
-          raise @context.class.config.input_exception_class.new(
-            context: @context,
-            message: message_text,
-            input_name:
-          )
+          @context.fail_input!(input_name, message: message_text)
         end
       end
     end

--- a/lib/servactory/context/workspace/inputs.rb
+++ b/lib/servactory/context/workspace/inputs.rb
@@ -68,11 +68,7 @@ module Servactory
             input_name: name
           )
 
-          raise @context.class.config.input_exception_class.new(
-            context: @context,
-            message: message_text,
-            input_name: name
-          )
+          @context.fail_input!(name, message: message_text)
         end
       end
     end

--- a/lib/servactory/context/workspace/internals.rb
+++ b/lib/servactory/context/workspace/internals.rb
@@ -80,10 +80,7 @@ module Servactory
             internal_name: name
           )
 
-          raise @context.class.config.internal_exception_class.new(
-            context: @context,
-            message: message_text
-          )
+          @context.fail_internal!(name, message: message_text)
         end
       end
     end

--- a/lib/servactory/context/workspace/outputs.rb
+++ b/lib/servactory/context/workspace/outputs.rb
@@ -74,10 +74,7 @@ module Servactory
             output_name: name
           )
 
-          raise @context.class.config.output_exception_class.new(
-            context: @context,
-            message: message_text
-          )
+          @context.fail_output!(name, message: message_text)
         end
       end
     end

--- a/lib/servactory/inputs/tools/rules.rb
+++ b/lib/servactory/inputs/tools/rules.rb
@@ -34,11 +34,7 @@ module Servactory
             conflict_code: input.conflict_code
           )
 
-          raise @context.class.config.input_exception_class.new(
-            context: @context,
-            message: message_text,
-            input_name: input.name
-          )
+          @context.fail_input!(input.name, message: message_text)
         end
       end
     end

--- a/lib/servactory/inputs/tools/unnecessary.rb
+++ b/lib/servactory/inputs/tools/unnecessary.rb
@@ -21,10 +21,7 @@ module Servactory
             unnecessary_attributes: unnecessary_attributes.join(", ")
           )
 
-          raise @context.class.config.input_exception_class.new(
-            context: @context,
-            message: message_text
-          )
+          @context.fail_input!(nil, message: message_text)
         end
 
         private

--- a/lib/servactory/inputs/tools/validation.rb
+++ b/lib/servactory/inputs/tools/validation.rb
@@ -74,10 +74,7 @@ module Servactory
         def raise_errors
           return if (tmp_errors = errors.not_blank).empty?
 
-          raise @context.class.config.input_exception_class.new(
-            context: @context,
-            message: tmp_errors.first
-          )
+          @context.fail_input!(nil, message: tmp_errors.first)
         end
       end
     end


### PR DESCRIPTION
Replaced explicit exception raising with centralized fail methods (`fail_input!`, `fail_output!`, and `fail_internal!`) across various context classes. Improves maintainability and reduces redundant code in input, output, and internal validation logic.